### PR TITLE
Verify DeepSeek-V2 rides on LlamaPlumbing structural matcher

### DIFF
--- a/tests/integration/test_model_families.py
+++ b/tests/integration/test_model_families.py
@@ -1,9 +1,10 @@
-"""Cross-family parity: Mistral and Qwen2 ride on LlamaPlumbing's structural matcher.
+"""Cross-family parity: Mistral, Qwen2, Gemma, and DeepSeek-V2 ride on
+LlamaPlumbing's structural matcher.
 
 LlamaPlumbing.matches() fires on any `{model}.model.{layers, embed_tokens,
-rotary_emb}` layout — Mistral and Qwen2 both satisfy this and their
-decoder-block forward signatures are byte-identical to Llama's. These
-tests lock that coverage in so a future HF refactor to either family
+rotary_emb}` layout — Mistral, Qwen2, Gemma, and DeepSeek-V2 all satisfy
+this and their decoder-block forward signatures are compatible with Llama's.
+These tests lock that coverage in so a future HF refactor to any family
 fails loudly rather than silently drifting.
 """
 from __future__ import annotations
@@ -162,4 +163,50 @@ def test_gemma_matches_naive() -> None:
     for i in range(N_LAYERS):
         assert torch.equal(got[i], expected[i].float()), (
             f"gemma layer {i}: max diff {(got[i] - expected[i].float()).abs().max().item()}"
+        )
+
+
+@pytest.mark.integration
+def test_deepseek_v2_matches_naive() -> None:
+    from transformers import DeepseekV2Config, DeepseekV2ForCausalLM
+
+    from fpwap.models import LlamaPlumbing, get_plumbing
+
+    config = DeepseekV2Config(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=INTER,
+        num_hidden_layers=N_LAYERS,
+        num_attention_heads=N_HEAD,
+        num_key_value_heads=N_KV_HEAD,
+        max_position_embeddings=SEQ_LEN,
+        kv_lora_rank=16,
+        q_lora_rank=32,
+        qk_nope_head_dim=HIDDEN // N_HEAD // 2,
+        qk_rope_head_dim=HIDDEN // N_HEAD // 2,
+        v_head_dim=HIDDEN // N_HEAD,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        first_k_dense_replace=1,
+        moe_intermediate_size=INTER,
+        n_group=1,
+        topk_group=1,
+        topk_method="greedy",
+        norm_topk_prob=True,
+    )
+    torch.manual_seed(SEED)
+    model = DeepseekV2ForCausalLM(config)
+    model.eval()
+
+    assert isinstance(get_plumbing(model), LlamaPlumbing)
+
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, VOCAB, (N_SAMPLES, SEQ_LEN))
+    expected = _capture_per_block(model, input_ids)
+    got = _run_fpwap(model, input_ids)
+
+    for i in range(N_LAYERS):
+        assert torch.equal(got[i], expected[i].float()), (
+            f"deepseek-v2 layer {i}: max diff {(got[i] - expected[i].float()).abs().max().item()}"
         )

--- a/tests/unit/test_final_norm.py
+++ b/tests/unit/test_final_norm.py
@@ -78,8 +78,60 @@ class TestLlamaFinalNorm:
             assert isinstance(obj, (nn.Parameter, torch.Tensor))
 
 
+def _make_tiny_deepseek_v2() -> nn.Module:
+    from transformers import DeepseekV2Config, DeepseekV2ForCausalLM
+
+    config = DeepseekV2Config(
+        vocab_size=40,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        max_position_embeddings=16,
+        kv_lora_rank=8,
+        q_lora_rank=16,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=8,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        first_k_dense_replace=1,
+        moe_intermediate_size=32,
+        n_group=1,
+        topk_group=1,
+        topk_method="greedy",
+        norm_topk_prob=True,
+    )
+    torch.manual_seed(0)
+    return DeepseekV2ForCausalLM(config).eval()
+
+
+class TestDeepSeekV2FinalNorm:
+    def test_returns_norm(self) -> None:
+        model = _make_tiny_deepseek_v2()
+        plumbing = LlamaPlumbing()
+        norm = plumbing.final_norm_module(model)
+        assert norm is model.model.norm  # type: ignore[union-attr]
+
+    def test_param_names(self) -> None:
+        model = _make_tiny_deepseek_v2()
+        plumbing = LlamaPlumbing()
+        names = plumbing.final_norm_param_names(model)
+        assert "model.norm.weight" in names
+        for name in names:
+            parts = name.split(".")
+            obj = model
+            for part in parts:
+                obj = getattr(obj, part)
+            assert isinstance(obj, (nn.Parameter, torch.Tensor))
+
+
 def test_get_plumbing_dispatches_final_norm() -> None:
     gpt2 = _make_tiny_gpt2()
     llama = _make_tiny_llama()
+    deepseek = _make_tiny_deepseek_v2()
     assert get_plumbing(gpt2).final_norm_module(gpt2) is not None
     assert get_plumbing(llama).final_norm_module(llama) is not None
+    assert get_plumbing(deepseek).final_norm_module(deepseek) is not None


### PR DESCRIPTION
## Summary

- Confirms that `LlamaPlumbing.matches()` fires on DeepSeek-V2's `model.{embed_tokens, layers, rotary_emb}` layout — no dedicated plumbing needed
- Decoder-block forward signature is compatible, including MoE layers (`DeepseekV2Moe`) on non-dense layers
- Both fast path and decomposed `attn_out`/`mlp_out` hooks produce bit-exact results against naive forward
- Final norm (`model.model.norm`) resolves correctly via the existing Llama path

Closes #2

## Test plan

- [x] `test_deepseek_v2_matches_naive` — bit-exact per-layer comparison of fpwap vs naive forward hooks on tiny DeepSeek-V2 with MoE routing
- [x] `TestDeepSeekV2FinalNorm::test_returns_norm` — plumbing returns `model.model.norm`
- [x] `TestDeepSeekV2FinalNorm::test_param_names` — param names resolve to real tensors
- [x] `test_get_plumbing_dispatches_final_norm` — extended to cover DeepSeek-V2
- [x] Full CI suite: 82 passed, ruff clean, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)