### PR TITLE
Add Extractor handle for multi-sweep model reuse

### DIFF
--- a/src/fpwap/__init__.py
+++ b/src/fpwap/__init__.py
@@ -1,5 +1,6 @@
 from fpwap.callbacks.base import Callback
 from fpwap.engine import Result, Sweep
+from fpwap.extractor import Extractor
 from fpwap.types import (
     Artifact,
     ArtifactKey,
@@ -15,6 +16,7 @@ __all__ = [
     "Callback",
     "Context",
     "Emit",
+    "Extractor",
     "LayerArtifact",
     "Result",
     "Sweep",

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -404,6 +404,7 @@ class Sweep:
         execution_device: torch.device | str | None = None,
         buffer_device: torch.device | str | None = None,
         apply_final_norm: bool = True,
+        _accel_index: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         self.model = model
         self.dataset = dataset
@@ -419,6 +420,7 @@ class Sweep:
         self.snapshot_dir = snapshot_dir
         self.offload_dir = offload_dir
         self.apply_final_norm = apply_final_norm
+        self._accel_index = _accel_index
         self.execution_device = (
             torch.device(execution_device) if execution_device is not None else None
         )
@@ -505,10 +507,18 @@ class Sweep:
         """Turn `self.model` into (concrete nn.Module, streamer).
 
         Pre-loaded nn.Module → _PreloadedStreamer (no-op per-layer).
+        Pre-loaded nn.Module + _accel_index → _OffloadStreamer (Extractor reuse).
         String snapshot path → build empty-weights model + _OffloadStreamer
         backed by OffloadedWeightsLoader.
         """
         if isinstance(self.model, nn.Module):
+            if self._accel_index is not None:
+                if self.execution_device is None:
+                    raise ValueError(
+                        "execution_device is required when using a pre-built accel_index "
+                        "(Extractor path)"
+                    )
+                return self.model, _OffloadStreamer(self._accel_index, self.execution_device)
             return self.model, _PreloadedStreamer(self.execution_device)
         if isinstance(self.model, str):
             if self.execution_device is None:

--- a/src/fpwap/extractor.py
+++ b/src/fpwap/extractor.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch import nn
+
+from fpwap.callbacks.base import Callback
+from fpwap.storage import StorageBackend
+from fpwap.types import LoadingStrategy
+
+if TYPE_CHECKING:
+    from fpwap.engine import Sweep
+
+
+class Extractor:
+    """Reusable handle that owns a pre-built empty model + accelerate index.
+
+    Multiple Sweeps against the same model reuse the cached artifacts instead
+    of rebuilding ``build_empty_model_and_index`` on each call — for 70B that
+    rebuild is real wall-clock burned on every eval dataset.
+
+    Sequential use only: do not start a new Sweep while a previous one is
+    still in-flight on the same Extractor.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        accel_index: dict[str, dict[str, Any]],
+        snapshot_dir: Path,
+        model_id: str,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        self._model = model
+        self._accel_index = accel_index
+        self._snapshot_dir = snapshot_dir
+        self._model_id = model_id
+        self._dtype = dtype
+
+    @classmethod
+    def from_hf(
+        cls,
+        model_id: str,
+        snapshot_dir: str | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> Extractor:
+        """Build an Extractor from an HF model ID or local snapshot path."""
+        from fpwap.loader import build_empty_model_and_index, resolve_snapshot_dir
+
+        if snapshot_dir is not None:
+            sdir = Path(snapshot_dir)
+        else:
+            sdir = resolve_snapshot_dir(model_id)
+
+        model, accel_index = build_empty_model_and_index(
+            model_id=model_id, snapshot_dir=sdir, dtype=dtype,
+        )
+        return cls(
+            model=model,
+            accel_index=accel_index,
+            snapshot_dir=sdir,
+            model_id=model_id,
+            dtype=dtype,
+        )
+
+    def sweep(
+        self,
+        dataset: Iterable[Any],
+        seq_len: int,
+        callbacks: Sequence[Callback],
+        storage: StorageBackend | None = None,
+        transport_dtype: torch.dtype | None = None,
+        loading_strategy: LoadingStrategy | None = None,
+        verify: bool = False,
+        progress: bool | Any = True,
+        seed: int = 0,
+        microbatch_size: int | None = None,
+        offload_dir: str | None = None,
+        execution_device: torch.device | str | None = None,
+        buffer_device: torch.device | str | None = None,
+        apply_final_norm: bool = True,
+    ) -> Sweep:
+        """Create a Sweep that reuses this Extractor's model and index."""
+        from fpwap.engine import Sweep
+
+        return Sweep(
+            model=self._model,
+            dataset=dataset,
+            seq_len=seq_len,
+            callbacks=callbacks,
+            storage=storage,
+            transport_dtype=transport_dtype if transport_dtype is not None else self._dtype,
+            loading_strategy=loading_strategy,
+            verify=verify,
+            progress=progress,
+            seed=seed,
+            microbatch_size=microbatch_size,
+            snapshot_dir=str(self._snapshot_dir),
+            offload_dir=offload_dir,
+            execution_device=execution_device,
+            buffer_device=buffer_device,
+            apply_final_norm=apply_final_norm,
+            _accel_index=self._accel_index,
+        )

--- a/tests/integration/test_extractor.py
+++ b/tests/integration/test_extractor.py
@@ -1,0 +1,202 @@
+"""Extractor handle: reuse empty_model + accel_index across sweeps.
+
+Proves that `Extractor.from_hf` builds once and `ext.sweep()` reuses the
+pre-built model and index — no rebuild on the second sweep. Uses a tiny
+GPT-2 snapshot saved to a temp dir; runs on CPU, no GPU required.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+SEED = 0
+N_SAMPLES = 4
+SEQ_LEN = 6
+HIDDEN = 16
+N_LAYERS = 2
+N_HEAD = 2
+VOCAB = 32
+
+
+def _write_tiny_gpt2_snapshot(snapshot_dir: Path) -> torch.nn.Module:
+    from transformers import GPT2Config, GPT2LMHeadModel
+
+    config = GPT2Config(
+        vocab_size=VOCAB,
+        n_positions=SEQ_LEN,
+        n_embd=HIDDEN,
+        n_layer=N_LAYERS,
+        n_head=N_HEAD,
+    )
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    config.save_pretrained(snapshot_dir)
+
+    torch.manual_seed(SEED)
+    src = GPT2LMHeadModel(config)
+    src.eval()
+
+    state_dict = {
+        k: v.contiguous() for k, v in src.state_dict().items() if k != "lm_head.weight"
+    }
+    save_file(state_dict, snapshot_dir / "model.safetensors")
+    hf_index = {
+        "metadata": {"total_size": 0},
+        "weight_map": {k: "model.safetensors" for k in state_dict},
+    }
+    (snapshot_dir / "model.safetensors.index.json").write_text(json.dumps(hf_index))
+    return src
+
+
+def _naive_per_layer_residual_post(
+    model: torch.nn.Module, input_ids: torch.Tensor
+) -> dict[int, torch.Tensor]:
+    captures: dict[int, torch.Tensor] = {}
+
+    def _make_hook(layer_idx: int):
+        def hook(_mod, _inp, out):
+            hidden = out[0] if isinstance(out, tuple) else out
+            captures[layer_idx] = hidden.detach().clone()
+
+        return hook
+
+    handles = []
+    for i, block in enumerate(model.transformer.h):
+        handles.append(block.register_forward_hook(_make_hook(i)))
+    try:
+        with torch.no_grad():
+            model(input_ids=input_ids)
+    finally:
+        for h in handles:
+            h.remove()
+    return captures
+
+
+@pytest.mark.integration
+def test_extractor_reuses_model_across_sweeps(tmp_path: Path) -> None:
+    from fpwap import Callback, Extractor
+    from fpwap.types import BatchResult, HookName
+
+    snapshot_dir = tmp_path / "snapshot"
+    src = _write_tiny_gpt2_snapshot(snapshot_dir)
+
+    torch.manual_seed(SEED + 1)
+    input_ids = torch.randint(0, VOCAB, (N_SAMPLES, SEQ_LEN))
+    baseline = _naive_per_layer_residual_post(src, input_ids)
+
+    ext = Extractor.from_hf(str(snapshot_dir), dtype=torch.float32)
+    model_id_first = id(ext._model)
+
+    class Capture(Callback):
+        phase = "read"
+        target_layers = "all"
+        target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+        def __init__(self) -> None:
+            self.acts: dict[int, torch.Tensor] = {
+                i: torch.zeros(N_SAMPLES, SEQ_LEN, HIDDEN) for i in range(N_LAYERS)
+            }
+
+        def on_batch(
+            self,
+            layer_idx: int,
+            hook: HookName,
+            acts: torch.Tensor,
+            sample_ids: torch.Tensor,
+        ) -> BatchResult:
+            self.acts[layer_idx][sample_ids] = acts.detach().float().cpu()
+            return None
+
+    results = []
+    for _ in range(2):
+        cap = Capture()
+        sweep = ext.sweep(
+            dataset=[{"input_ids": input_ids[i : i + 1]} for i in range(N_SAMPLES)],
+            seq_len=SEQ_LEN,
+            callbacks=[cap],
+            transport_dtype=torch.float32,
+            execution_device="cpu",
+            seed=SEED,
+            apply_final_norm=False,
+            progress=False,
+        )
+        sweep.run()
+        results.append(cap.acts)
+
+    assert id(ext._model) == model_id_first, "model object was rebuilt"
+
+    for layer_idx, baseline_hidden in baseline.items():
+        for run_idx, acts in enumerate(results):
+            got = acts[layer_idx]
+            max_diff = (got - baseline_hidden).abs().max().item()
+            assert torch.allclose(got, baseline_hidden, atol=1e-5, rtol=1e-5), (
+                f"sweep {run_idx} layer {layer_idx} mismatch: max abs diff {max_diff}"
+            )
+
+    for layer_idx in range(N_LAYERS):
+        assert torch.equal(results[0][layer_idx], results[1][layer_idx]), (
+            f"sweeps diverged at layer {layer_idx}"
+        )
+
+
+@pytest.mark.integration
+def test_extractor_sweep_uses_streaming_path(tmp_path: Path) -> None:
+    """Extractor sweeps must use the streaming path (weight I/O > 0)."""
+    from fpwap import Extractor
+    from fpwap.callbacks.common import RawActivations
+
+    snapshot_dir = tmp_path / "snapshot"
+    _write_tiny_gpt2_snapshot(snapshot_dir)
+
+    ext = Extractor.from_hf(str(snapshot_dir), dtype=torch.float32)
+
+    torch.manual_seed(SEED + 1)
+    input_ids = torch.randint(0, VOCAB, (N_SAMPLES, SEQ_LEN))
+
+    raw = RawActivations(layers="all", last_token_only=False, out_dtype=torch.float32)
+    sweep = ext.sweep(
+        dataset=[{"input_ids": input_ids[i : i + 1]} for i in range(N_SAMPLES)],
+        seq_len=SEQ_LEN,
+        callbacks=[raw],
+        transport_dtype=torch.float32,
+        execution_device="cpu",
+        seed=SEED,
+        apply_final_norm=False,
+        progress=False,
+    )
+    result = sweep.run()
+
+    assert result.profile.bytes_moved()["weights"] > 0, (
+        "Extractor sweep should use streaming path (non-zero weight I/O)"
+    )
+
+
+@pytest.mark.integration
+def test_extractor_requires_execution_device(tmp_path: Path) -> None:
+    """Extractor.sweep() without execution_device must raise."""
+    from fpwap import Extractor
+    from fpwap.callbacks.common import RawActivations
+
+    snapshot_dir = tmp_path / "snapshot"
+    _write_tiny_gpt2_snapshot(snapshot_dir)
+
+    ext = Extractor.from_hf(str(snapshot_dir), dtype=torch.float32)
+
+    torch.manual_seed(SEED + 1)
+    input_ids = torch.randint(0, VOCAB, (2, SEQ_LEN))
+
+    raw = RawActivations(layers="all", last_token_only=False, out_dtype=torch.float32)
+    sweep = ext.sweep(
+        dataset=[{"input_ids": input_ids[i : i + 1]} for i in range(2)],
+        seq_len=SEQ_LEN,
+        callbacks=[raw],
+        transport_dtype=torch.float32,
+        seed=SEED,
+        apply_final_norm=False,
+        progress=False,
+    )
+    with pytest.raises(ValueError, match="execution_device is required"):
+        sweep.run()


### PR DESCRIPTION
## Summary

- Adds `fpwap.Extractor` — a thin wrapper that caches `(empty_model, accel_index, snapshot_dir)` from `build_empty_model_and_index` so multiple Sweeps against the same model skip the rebuild
- `Extractor.from_hf(model_id)` builds once; `ext.sweep(...)` creates Sweeps that reuse the pre-built artifacts via a private `_accel_index` parameter on Sweep
- For 70B, this eliminates redundant config parsing + safetensors shard inspection across 15+ eval datasets per experiment pass

## Changes

- `src/fpwap/extractor.py` — new `Extractor` class with `from_hf()` classmethod and `sweep()` method
- `src/fpwap/engine.py` — `Sweep.__init__` accepts private `_accel_index`; `_resolve_model_and_streamer` routes to `_OffloadStreamer` when set
- `src/fpwap/__init__.py` — exports `Extractor`
- `tests/integration/test_extractor.py` — three tests: reuse across sweeps (bit-exact), streaming path verification, execution_device requirement

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src` — clean (16 source files)
- [x] `uv run pytest -m 'not gpu and not integration'` — 43/43 pass (no regressions)
- [x] `uv run pytest tests/integration/test_extractor.py -v -m integration` — 3/3 pass
- [ ] CI lint + mypy + unit tests

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)