### PR TITLE
Add multi-dataset warm-start benchmark

### DIFF
--- a/scripts/bench_warm_start.py
+++ b/scripts/bench_warm_start.py
@@ -1,0 +1,299 @@
+"""fpwap multi-dataset warm-start benchmark.
+
+Proves the Extractor handle eliminates per-sweep build_empty_model_and_index
+cost across back-to-back sweeps. The multi-eval-dataset pattern (15+ datasets
+per experiment pass) is the motivating use case.
+
+Two modes:
+  warm  — Extractor.from_hf() once, then ext.sweep() × N (handle reuse)
+  cold  — Sweep(model=str) × N (rebuilds empty model + accel_index each time)
+
+Reports: total wall-clock, setup portion, per-sweep median, speedup ratio.
+
+Usage:
+    uv run scripts/bench_warm_start.py \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --n-sweeps 15 --n-samples 32 --seq-len 128
+
+    uv run scripts/bench_warm_start.py \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --n-sweeps 15 --mode cold \\
+        --n-samples 32 --seq-len 128
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from transformers import AutoTokenizer
+
+from fpwap import Callback, Extractor, Sweep
+from fpwap.loader import resolve_snapshot_dir
+from fpwap.types import BatchResult, HookName
+
+
+class NullCapture(Callback):
+    """Minimal callback — forces forward work without shaping measurement."""
+
+    phase = "read"
+    target_layers = "all"
+    target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+    def __init__(self) -> None:
+        self.touches = 0
+
+    def on_batch(
+        self,
+        layer_idx: int,
+        hook: HookName,
+        acts: torch.Tensor,
+        sample_ids: torch.Tensor,
+    ) -> BatchResult:
+        self.touches += int(acts.shape[0])
+        return None
+
+
+def summarize_timings(
+    setup_s: float,
+    sweep_times: list[float],
+) -> dict[str, float]:
+    """Compute summary statistics from raw warm-start timing data.
+
+    Returns a dict with: n_sweeps, setup_s, total_run_s, total_s,
+    median_sweep_s, mean_sweep_s, min_sweep_s, max_sweep_s,
+    setup_fraction.
+    """
+    total_run_s = sum(sweep_times)
+    total_s = setup_s + total_run_s
+    n = len(sweep_times)
+    return {
+        "n_sweeps": float(n),
+        "setup_s": setup_s,
+        "total_run_s": total_run_s,
+        "total_s": total_s,
+        "median_sweep_s": statistics.median(sweep_times) if n > 0 else 0.0,
+        "mean_sweep_s": statistics.mean(sweep_times) if n > 0 else 0.0,
+        "min_sweep_s": min(sweep_times) if n > 0 else 0.0,
+        "max_sweep_s": max(sweep_times) if n > 0 else 0.0,
+        "setup_fraction": setup_s / total_s if total_s > 0 else 0.0,
+    }
+
+
+def _build_dataset(
+    tokenizer: Any,
+    n_samples: int,
+    seq_len: int,
+) -> list[dict[str, torch.Tensor]]:
+    prompts = [
+        f"The quick brown fox jumps over the lazy dog number {i}."
+        for i in range(n_samples)
+    ]
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
+    batch = tokenizer(
+        prompts,
+        padding="max_length",
+        truncation=True,
+        max_length=seq_len,
+        return_tensors="pt",
+    )
+    input_ids: torch.Tensor = batch["input_ids"]
+    attention_mask: torch.Tensor = batch["attention_mask"]
+    return [
+        {
+            "input_ids": input_ids[i : i + 1],
+            "attention_mask": attention_mask[i : i + 1],
+        }
+        for i in range(n_samples)
+    ]
+
+
+def _run_warm(
+    model_id: str,
+    dataset: list[dict[str, torch.Tensor]],
+    n_sweeps: int,
+    seq_len: int,
+    dtype: torch.dtype,
+    device: str,
+    microbatch: int | None,
+    buffer_device: str | None,
+) -> tuple[float, list[float]]:
+    """Warm path: Extractor.from_hf() once, then N sweeps reusing handle."""
+    use_cuda = torch.cuda.is_available() and "cuda" in device
+
+    if use_cuda:
+        torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    ext = Extractor.from_hf(model_id, dtype=dtype)
+    if use_cuda:
+        torch.cuda.synchronize()
+    setup_s = time.perf_counter() - t0
+
+    sweep_times: list[float] = []
+    for _ in range(n_sweeps):
+        cb = NullCapture()
+        sweep = ext.sweep(
+            dataset=dataset,
+            seq_len=seq_len,
+            callbacks=[cb],
+            transport_dtype=dtype,
+            execution_device=device,
+            microbatch_size=microbatch,
+            seed=0,
+            progress=False,
+            apply_final_norm=False,
+            buffer_device=buffer_device,
+        )
+        if use_cuda:
+            torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        sweep.run()
+        if use_cuda:
+            torch.cuda.synchronize()
+        sweep_times.append(time.perf_counter() - t0)
+
+    return setup_s, sweep_times
+
+
+def _run_cold(
+    model_id: str,
+    snapshot_dir: Path,
+    dataset: list[dict[str, torch.Tensor]],
+    n_sweeps: int,
+    seq_len: int,
+    dtype: torch.dtype,
+    device: str,
+    microbatch: int | None,
+    buffer_device: str | None,
+) -> tuple[float, list[float]]:
+    """Cold path: N × Sweep(model=str), each rebuilds empty model + index."""
+    use_cuda = torch.cuda.is_available() and "cuda" in device
+
+    sweep_times: list[float] = []
+    for _ in range(n_sweeps):
+        cb = NullCapture()
+        sweep = Sweep(
+            model=str(snapshot_dir),
+            dataset=dataset,
+            seq_len=seq_len,
+            callbacks=[cb],
+            transport_dtype=dtype,
+            execution_device=device,
+            microbatch_size=microbatch,
+            seed=0,
+            progress=False,
+            apply_final_norm=False,
+            buffer_device=buffer_device,
+        )
+        if use_cuda:
+            torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        sweep.run()
+        if use_cuda:
+            torch.cuda.synchronize()
+        sweep_times.append(time.perf_counter() - t0)
+
+    return 0.0, sweep_times
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="HF model ID or local snapshot path")
+    parser.add_argument("--n-sweeps", type=int, default=15)
+    parser.add_argument("--n-samples", type=int, default=32)
+    parser.add_argument("--seq-len", type=int, default=128)
+    parser.add_argument("--microbatch", type=int, default=None)
+    parser.add_argument("--mode", choices=["warm", "cold", "both"], default="both")
+    parser.add_argument("--dtype", choices=["bfloat16", "float16", "float32"], default="bfloat16")
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--buffer-device", default=None)
+    parser.add_argument("--out", default=None, help="CSV output path")
+    args = parser.parse_args()
+
+    dtype = getattr(torch, args.dtype)
+    snapshot_dir = resolve_snapshot_dir(args.model)
+    tokenizer = AutoTokenizer.from_pretrained(snapshot_dir)
+    dataset = _build_dataset(tokenizer, args.n_samples, args.seq_len)
+
+    rows: list[dict[str, object]] = []
+    header = [
+        "model", "mode", "n_sweeps", "n_samples", "seq_len",
+        "setup_s", "total_run_s", "total_s",
+        "median_sweep_s", "mean_sweep_s", "min_sweep_s", "max_sweep_s",
+        "setup_fraction",
+    ]
+
+    modes = ["warm", "cold"] if args.mode == "both" else [args.mode]
+    for mode in modes:
+        print(f"\n[bench_warm_start] {mode} — {args.model}, {args.n_sweeps} sweeps")
+        if mode == "warm":
+            setup_s, sweep_times = _run_warm(
+                model_id=args.model,
+                dataset=dataset,
+                n_sweeps=args.n_sweeps,
+                seq_len=args.seq_len,
+                dtype=dtype,
+                device=args.device,
+                microbatch=args.microbatch,
+                buffer_device=args.buffer_device,
+            )
+        else:
+            setup_s, sweep_times = _run_cold(
+                model_id=args.model,
+                snapshot_dir=snapshot_dir,
+                dataset=dataset,
+                n_sweeps=args.n_sweeps,
+                seq_len=args.seq_len,
+                dtype=dtype,
+                device=args.device,
+                microbatch=args.microbatch,
+                buffer_device=args.buffer_device,
+            )
+
+        stats = summarize_timings(setup_s, sweep_times)
+        row: dict[str, object] = {
+            "model": args.model,
+            "mode": mode,
+            "n_sweeps": args.n_sweeps,
+            "n_samples": args.n_samples,
+            "seq_len": args.seq_len,
+        }
+        for k, v in stats.items():
+            if k == "n_sweeps":
+                continue
+            row[k] = f"{v:.4f}"
+        rows.append(row)
+
+        print(f"  setup            : {stats['setup_s']:.3f} s")
+        print(f"  total run        : {stats['total_run_s']:.3f} s")
+        print(f"  total            : {stats['total_s']:.3f} s")
+        print(f"  median sweep     : {stats['median_sweep_s']:.4f} s")
+        print(f"  mean sweep       : {stats['mean_sweep_s']:.4f} s")
+        print(f"  min/max sweep    : {stats['min_sweep_s']:.4f} / {stats['max_sweep_s']:.4f} s")
+        print(f"  setup fraction   : {stats['setup_fraction']:.1%}")
+        print(f"  per-sweep times  : {[f'{t:.3f}' for t in sweep_times]}")
+
+    if len(rows) == 2:
+        warm_total = float(rows[0]["total_s"])  # type: ignore[arg-type]
+        cold_total = float(rows[1]["total_s"])  # type: ignore[arg-type]
+        if warm_total > 0:
+            print(f"\n  speedup (cold/warm): {cold_total / warm_total:.2f}×")
+
+    if args.out is not None:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=header)
+            w.writeheader()
+            w.writerows(rows)
+        print(f"\nwrote {len(rows)} rows to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_warm_start.py
+++ b/tests/integration/test_warm_start.py
@@ -1,0 +1,187 @@
+"""Integration test for multi-dataset warm-start via Extractor handle.
+
+Proves that running N sweeps back-to-back through the same Extractor
+reuses the model object (no rebuild) and produces consistent results.
+Uses a tiny GPT-2 snapshot; CPU-only, no GPU required.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from fpwap import Callback, Extractor, Sweep
+from fpwap.types import BatchResult, HookName
+
+SEED = 0
+N_SAMPLES = 4
+SEQ_LEN = 6
+HIDDEN = 16
+N_LAYERS = 2
+N_HEAD = 2
+VOCAB = 32
+N_SWEEPS = 5
+
+
+def _write_tiny_gpt2_snapshot(snapshot_dir: Path) -> None:
+    from transformers import GPT2Config, GPT2LMHeadModel
+
+    config = GPT2Config(
+        vocab_size=VOCAB,
+        n_positions=SEQ_LEN,
+        n_embd=HIDDEN,
+        n_layer=N_LAYERS,
+        n_head=N_HEAD,
+    )
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    config.save_pretrained(snapshot_dir)
+
+    torch.manual_seed(SEED)
+    src = GPT2LMHeadModel(config)
+    src.eval()
+
+    state_dict = {
+        k: v.contiguous() for k, v in src.state_dict().items() if k != "lm_head.weight"
+    }
+    save_file(state_dict, snapshot_dir / "model.safetensors")
+    hf_index = {
+        "metadata": {"total_size": 0},
+        "weight_map": {k: "model.safetensors" for k in state_dict},
+    }
+    (snapshot_dir / "model.safetensors.index.json").write_text(json.dumps(hf_index))
+
+
+class _TouchCounter(Callback):
+    phase = "read"
+    target_layers = "all"
+    target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+    def __init__(self) -> None:
+        self.touches = 0
+
+    def on_batch(
+        self,
+        layer_idx: int,
+        hook: HookName,
+        acts: torch.Tensor,
+        sample_ids: torch.Tensor,
+    ) -> BatchResult:
+        self.touches += int(acts.shape[0])
+        return None
+
+
+def _make_dataset() -> list[dict[str, torch.Tensor]]:
+    torch.manual_seed(SEED + 1)
+    input_ids = torch.randint(0, VOCAB, (N_SAMPLES, SEQ_LEN))
+    return [{"input_ids": input_ids[i : i + 1]} for i in range(N_SAMPLES)]
+
+
+@pytest.mark.integration
+def test_warm_start_reuses_model(tmp_path: Path) -> None:
+    """Extractor model object identity is stable across N sweeps."""
+    snapshot_dir = tmp_path / "snapshot"
+    _write_tiny_gpt2_snapshot(snapshot_dir)
+
+    ext = Extractor.from_hf(str(snapshot_dir), dtype=torch.float32)
+    model_id_at_start = id(ext._model)
+
+    dataset = _make_dataset()
+    for _ in range(N_SWEEPS):
+        cb = _TouchCounter()
+        sweep = ext.sweep(
+            dataset=dataset,
+            seq_len=SEQ_LEN,
+            callbacks=[cb],
+            transport_dtype=torch.float32,
+            execution_device="cpu",
+            seed=SEED,
+            progress=False,
+            apply_final_norm=False,
+        )
+        sweep.run()
+        assert cb.touches == N_SAMPLES * N_LAYERS
+
+    assert id(ext._model) == model_id_at_start, "model was rebuilt during sweeps"
+
+
+@pytest.mark.integration
+def test_warm_start_consistent_profiles(tmp_path: Path) -> None:
+    """All N sweeps should report non-zero weight I/O (streaming path)."""
+    snapshot_dir = tmp_path / "snapshot"
+    _write_tiny_gpt2_snapshot(snapshot_dir)
+
+    ext = Extractor.from_hf(str(snapshot_dir), dtype=torch.float32)
+    dataset = _make_dataset()
+
+    weight_bytes_per_sweep: list[int] = []
+    for _ in range(N_SWEEPS):
+        cb = _TouchCounter()
+        sweep = ext.sweep(
+            dataset=dataset,
+            seq_len=SEQ_LEN,
+            callbacks=[cb],
+            transport_dtype=torch.float32,
+            execution_device="cpu",
+            seed=SEED,
+            progress=False,
+            apply_final_norm=False,
+        )
+        result = sweep.run()
+        weight_bytes_per_sweep.append(result.profile.bytes_moved()["weights"])
+
+    assert all(b > 0 for b in weight_bytes_per_sweep), (
+        "warm sweeps should still use streaming path (non-zero weight I/O)"
+    )
+    assert len(set(weight_bytes_per_sweep)) == 1, (
+        f"weight I/O should be identical across sweeps: {weight_bytes_per_sweep}"
+    )
+
+
+@pytest.mark.integration
+def test_warm_vs_cold_setup_cost(tmp_path: Path) -> None:
+    """Warm-start amortizes setup: N warm sweeps should be faster than N cold."""
+    snapshot_dir = tmp_path / "snapshot"
+    _write_tiny_gpt2_snapshot(snapshot_dir)
+    dataset = _make_dataset()
+
+    t0 = time.perf_counter()
+    ext = Extractor.from_hf(str(snapshot_dir), dtype=torch.float32)
+    for _ in range(N_SWEEPS):
+        cb = _TouchCounter()
+        sweep = ext.sweep(
+            dataset=dataset,
+            seq_len=SEQ_LEN,
+            callbacks=[cb],
+            transport_dtype=torch.float32,
+            execution_device="cpu",
+            seed=SEED,
+            progress=False,
+            apply_final_norm=False,
+        )
+        sweep.run()
+    warm_total = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    for _ in range(N_SWEEPS):
+        cb = _TouchCounter()
+        sweep = Sweep(
+            model=str(snapshot_dir),
+            dataset=dataset,
+            seq_len=SEQ_LEN,
+            callbacks=[cb],
+            transport_dtype=torch.float32,
+            execution_device="cpu",
+            seed=SEED,
+            progress=False,
+            apply_final_norm=False,
+        )
+        sweep.run()
+    cold_total = time.perf_counter() - t0
+
+    assert warm_total < cold_total, (
+        f"warm ({warm_total:.3f}s) should be faster than cold ({cold_total:.3f}s)"
+    )

--- a/tests/unit/test_warm_start_stats.py
+++ b/tests/unit/test_warm_start_stats.py
@@ -1,0 +1,63 @@
+"""Unit tests for bench_warm_start.summarize_timings — CI-safe, no model."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from bench_warm_start import summarize_timings
+
+
+def test_summarize_basic() -> None:
+    stats = summarize_timings(setup_s=1.0, sweep_times=[2.0, 3.0, 4.0])
+    assert stats["n_sweeps"] == 3.0
+    assert stats["setup_s"] == 1.0
+    assert stats["total_run_s"] == 9.0
+    assert stats["total_s"] == 10.0
+    assert stats["median_sweep_s"] == 3.0
+    assert abs(stats["mean_sweep_s"] - 3.0) < 1e-9
+    assert stats["min_sweep_s"] == 2.0
+    assert stats["max_sweep_s"] == 4.0
+    assert abs(stats["setup_fraction"] - 0.1) < 1e-9
+
+
+def test_summarize_single_sweep() -> None:
+    stats = summarize_timings(setup_s=0.5, sweep_times=[1.5])
+    assert stats["n_sweeps"] == 1.0
+    assert stats["median_sweep_s"] == 1.5
+    assert stats["mean_sweep_s"] == 1.5
+    assert stats["total_s"] == 2.0
+    assert abs(stats["setup_fraction"] - 0.25) < 1e-9
+
+
+def test_summarize_zero_setup() -> None:
+    stats = summarize_timings(setup_s=0.0, sweep_times=[1.0, 2.0])
+    assert stats["setup_s"] == 0.0
+    assert stats["setup_fraction"] == 0.0
+    assert stats["total_s"] == 3.0
+
+
+def test_summarize_empty_sweeps() -> None:
+    stats = summarize_timings(setup_s=1.0, sweep_times=[])
+    assert stats["n_sweeps"] == 0.0
+    assert stats["median_sweep_s"] == 0.0
+    assert stats["total_run_s"] == 0.0
+    assert stats["total_s"] == 1.0
+    assert abs(stats["setup_fraction"] - 1.0) < 1e-9
+
+
+def test_summarize_even_count_median() -> None:
+    stats = summarize_timings(setup_s=0.0, sweep_times=[1.0, 2.0, 3.0, 4.0])
+    assert stats["median_sweep_s"] == 2.5
+
+
+def test_summarize_identical_sweeps() -> None:
+    stats = summarize_timings(setup_s=2.0, sweep_times=[1.0] * 15)
+    assert stats["n_sweeps"] == 15.0
+    assert stats["median_sweep_s"] == 1.0
+    assert stats["mean_sweep_s"] == 1.0
+    assert stats["min_sweep_s"] == 1.0
+    assert stats["max_sweep_s"] == 1.0
+    assert stats["total_run_s"] == 15.0
+    assert stats["total_s"] == 17.0


### PR DESCRIPTION
## Summary

- Adds `scripts/bench_warm_start.py` — benchmark proving Extractor handle reuse eliminates per-sweep `build_empty_model_and_index` cost across 15+ back-to-back sweeps
- Supports `warm` (Extractor reuse) vs `cold` (rebuild each time) comparison with CSV output
- 6 unit tests for `summarize_timings` stats helper (CI-safe)
- 3 integration tests with tiny GPT-2: model reuse, consistent profiles, warm-vs-cold speedup

Closes #9

## Test plan

- [x] 54 unit tests pass (`pytest -m 'not gpu and not integration'`)
- [x] 3 integration tests pass (`test_warm_start.py`)
- [x] ruff clean
- [x] mypy clean
- [ ] CI green on Python 3.11 and 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)