### PR TITLE
Fix harness adapter return contract and capture OOM

### DIFF
--- a/scripts/harness_adapter.py
+++ b/scripts/harness_adapter.py
@@ -26,22 +26,25 @@ from fpwap.types import BatchResult, HookName
 
 
 class _FingerprintCapture(Callback):
-    """Captures residual_post at specified layers for fingerprinting."""
+    """Captures per-sample masked-mean of residual_post for fingerprinting.
+
+    Stores O(N × H) per layer (pooled), not O(N × S × H).
+    """
 
     phase = "read"
 
     def __init__(
         self,
         n_samples: int,
-        seq_len: int,
         hidden_size: int,
         layers: list[int],
-        dtype: torch.dtype,
+        attention_mask: Tensor | None = None,
     ) -> None:
         self.target_layers = layers
         self.target_hooks: tuple[HookName, ...] = ("residual_post",)
-        self.acts: dict[int, Tensor] = {
-            i: torch.zeros(n_samples, seq_len, hidden_size, dtype=dtype)
+        self.attention_mask = attention_mask
+        self.pooled: dict[int, Tensor] = {
+            i: torch.zeros(n_samples, hidden_size, dtype=torch.float32)
             for i in layers
         }
 
@@ -52,28 +55,30 @@ class _FingerprintCapture(Callback):
         acts: Tensor,
         sample_ids: Tensor,
     ) -> BatchResult:
-        self.acts[layer_idx][sample_ids] = acts.detach().to(self.acts[layer_idx].dtype).cpu()
+        if self.attention_mask is not None:
+            mask = self.attention_mask[sample_ids.cpu()].bool().unsqueeze(-1).float()
+            mask = mask.to(acts.device)
+            num = (acts.float() * mask).sum(dim=1)
+            den = mask.sum(dim=1).clamp(min=1.0)
+            pooled = num / den
+        else:
+            pooled = acts.float().mean(dim=1)
+        self.pooled[layer_idx][sample_ids.cpu()] = pooled.cpu()
         return None
 
 
-def compute_fingerprint(
-    acts: dict[int, Tensor],
-    attention_mask: Tensor | None,
-) -> float:
-    """Per-batch mean of non-pad residuals across captured layers.
+def compute_fingerprint(pooled: dict[int, Tensor]) -> Tensor:
+    """Per-sample mean of non-pad residuals across captured layers.
 
-    Mask pad positions, mean over (sample, position, hidden) dims for each
-    layer, then mean across layers -> single scalar determinism check.
+    Args:
+        pooled: {layer_idx: [N, H]} tensors, already position-pooled.
+
+    Returns:
+        [N, L*H] tensor — per-sample fingerprint concatenated across layers.
     """
-    layer_means: list[float] = []
-    for _layer_idx, hidden in sorted(acts.items()):
-        if attention_mask is not None:
-            mask = attention_mask.bool().unsqueeze(-1)
-            vals = hidden.float().masked_select(mask)
-        else:
-            vals = hidden.float().flatten()
-        layer_means.append(vals.mean().item())
-    return sum(layer_means) / len(layer_means) if layer_means else 0.0
+    if not pooled:
+        return torch.empty(0, 0)
+    return torch.cat([pooled[i] for i in sorted(pooled)], dim=-1)
 
 
 def run_fpwap(
@@ -86,7 +91,7 @@ def run_fpwap(
     dtype: torch.dtype = torch.bfloat16,
     microbatch_size: int | None = None,
     attention_mask: Tensor | None = None,
-) -> tuple[float, list[float], float, float]:
+) -> tuple[float, list[float], Tensor, float]:
     """Run fpwap extraction and return the harness contract tuple.
 
     Args:
@@ -102,8 +107,8 @@ def run_fpwap(
     Returns:
         load_s: Extractor build time (empty model + accel_index).
         extract_times: Per-iteration wall-clock seconds.
-        fingerprint: Per-batch mean of non-pad residuals (scalar).
-        peak_VRAM: Peak GPU memory in bytes via torch.cuda.max_memory_allocated.
+        fingerprint: [N, L*H] tensor — per-sample masked-mean across layers.
+        peak_VRAM: Peak GPU memory in GB.
     """
     use_cuda = torch.cuda.is_available() and "cuda" in device
 
@@ -132,15 +137,14 @@ def run_fpwap(
         dataset.append(item)
 
     extract_times: list[float] = []
-    fingerprint = 0.0
+    fingerprint = torch.empty(0, 0)
 
     for _ in range(iters):
         cap = _FingerprintCapture(
             n_samples=n_samples,
-            seq_len=seq_len,
             hidden_size=hidden_size,
             layers=hf_layers,
-            dtype=dtype,
+            attention_mask=attention_mask,
         )
         sweep = ext.sweep(
             dataset=dataset,
@@ -150,7 +154,7 @@ def run_fpwap(
             execution_device=device,
             microbatch_size=microbatch_size,
             seed=0,
-            progress=False,
+            progress=True,
             apply_final_norm=False,
         )
 
@@ -162,9 +166,11 @@ def run_fpwap(
             torch.cuda.synchronize()
         extract_times.append(time.perf_counter() - t0)
 
-        fingerprint = compute_fingerprint(cap.acts, attention_mask)
+        fingerprint = compute_fingerprint(cap.pooled)
 
-    peak_vram = float(torch.cuda.max_memory_allocated()) if use_cuda else 0.0
+    peak_vram = (
+        torch.cuda.max_memory_allocated() / (1024**3) if use_cuda else 0.0
+    )
 
     return load_s, extract_times, fingerprint, peak_vram
 
@@ -226,8 +232,8 @@ def main() -> None:
     print(f"=== harness_adapter: {args.model} ===")
     print(f"  load_s          : {load_s:.3f}")
     print(f"  extract_times   : {[f'{t:.3f}' for t in extract_times]}")
-    print(f"  fingerprint     : {fingerprint:.8f}")
-    print(f"  peak_VRAM (MB)  : {peak_vram / 1e6:.1f}")
+    print(f"  fingerprint     : {tuple(fingerprint.shape)}, mean={fingerprint.float().mean():.8f}")
+    print(f"  peak_VRAM (GB)  : {peak_vram:.2f}")
     print(f"  iters           : {args.iters}")
     print(f"  N               : {args.n_samples}")
     print(f"  seq_len         : {args.seq_len}")

--- a/tests/integration/test_harness_adapter.py
+++ b/tests/integration/test_harness_adapter.py
@@ -7,7 +7,6 @@ required.
 from __future__ import annotations
 
 import json
-import math
 import sys
 from pathlib import Path
 
@@ -77,20 +76,23 @@ def test_run_fpwap_contract(tmp_path: Path) -> None:
     assert isinstance(load_s, float) and load_s > 0
     assert isinstance(extract_times, list) and len(extract_times) == 2
     assert all(t > 0 for t in extract_times)
-    assert isinstance(fingerprint, float) and math.isfinite(fingerprint)
+    assert isinstance(fingerprint, torch.Tensor)
+    assert fingerprint.ndim == 2
+    assert fingerprint.shape[0] == N_SAMPLES
+    assert fingerprint.shape[1] == N_LAYERS * HIDDEN
     assert isinstance(peak_vram, float)
 
 
 @pytest.mark.integration
 def test_run_fpwap_fingerprint_stable(tmp_path: Path) -> None:
-    """Same inputs -> same fingerprint across iters."""
+    """Same inputs -> same fingerprint across calls."""
     snapshot_dir = tmp_path / "snapshot"
     _write_tiny_gpt2_snapshot(snapshot_dir)
 
     torch.manual_seed(SEED + 1)
     input_ids = torch.randint(0, VOCAB, (N_SAMPLES, SEQ_LEN))
 
-    _, times1, fp1, _ = run_fpwap(
+    _, _, fp1, _ = run_fpwap(
         model_id=str(snapshot_dir),
         pretokenized_batch=input_ids,
         hf_layers=[0, 1],
@@ -98,7 +100,7 @@ def test_run_fpwap_fingerprint_stable(tmp_path: Path) -> None:
         device="cpu",
         dtype=torch.float32,
     )
-    _, times2, fp2, _ = run_fpwap(
+    _, _, fp2, _ = run_fpwap(
         model_id=str(snapshot_dir),
         pretokenized_batch=input_ids,
         hf_layers=[0, 1],
@@ -107,7 +109,7 @@ def test_run_fpwap_fingerprint_stable(tmp_path: Path) -> None:
         dtype=torch.float32,
     )
 
-    assert fp1 == fp2, f"fingerprint drifted: {fp1} vs {fp2}"
+    assert torch.equal(fp1, fp2), f"fingerprint drifted: {fp1} vs {fp2}"
 
 
 @pytest.mark.integration
@@ -130,5 +132,39 @@ def test_run_fpwap_with_attention_mask(tmp_path: Path) -> None:
         attention_mask=attention_mask,
     )
 
-    assert math.isfinite(fingerprint)
+    assert isinstance(fingerprint, torch.Tensor)
+    assert fingerprint.shape == (N_SAMPLES, HIDDEN)
+    assert torch.isfinite(fingerprint).all()
     assert len(extract_times) == 1
+
+
+@pytest.mark.integration
+def test_run_fpwap_mask_affects_fingerprint(tmp_path: Path) -> None:
+    """Masking pad tokens should change the fingerprint vs no mask."""
+    snapshot_dir = tmp_path / "snapshot"
+    _write_tiny_gpt2_snapshot(snapshot_dir)
+
+    torch.manual_seed(SEED + 1)
+    input_ids = torch.randint(0, VOCAB, (N_SAMPLES, SEQ_LEN))
+    attention_mask = torch.ones(N_SAMPLES, SEQ_LEN, dtype=torch.long)
+    attention_mask[:, :2] = 0
+
+    _, _, fp_masked, _ = run_fpwap(
+        model_id=str(snapshot_dir),
+        pretokenized_batch=input_ids,
+        hf_layers=[0],
+        iters=1,
+        device="cpu",
+        dtype=torch.float32,
+        attention_mask=attention_mask,
+    )
+    _, _, fp_unmasked, _ = run_fpwap(
+        model_id=str(snapshot_dir),
+        pretokenized_batch=input_ids,
+        hf_layers=[0],
+        iters=1,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    assert not torch.equal(fp_masked, fp_unmasked)

--- a/tests/unit/test_harness_fingerprint.py
+++ b/tests/unit/test_harness_fingerprint.py
@@ -1,7 +1,6 @@
 """Unit tests for harness_adapter.compute_fingerprint — CI-safe, no model."""
 from __future__ import annotations
 
-import math
 import sys
 from pathlib import Path
 
@@ -12,40 +11,46 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 from harness_adapter import compute_fingerprint
 
 
-def test_fingerprint_no_mask() -> None:
-    acts = {0: torch.ones(2, 4, 8)}
-    fp = compute_fingerprint(acts, attention_mask=None)
-    assert fp == 1.0
+def test_fingerprint_no_mask_shape() -> None:
+    pooled = {0: torch.ones(2, 8)}
+    fp = compute_fingerprint(pooled)
+    assert isinstance(fp, torch.Tensor)
+    assert fp.shape == (2, 8)
 
 
-def test_fingerprint_with_mask_excludes_pad() -> None:
-    acts = {0: torch.full((2, 4, 8), 5.0)}
-    acts[0][0, :2, :] = 0.0
-    mask = torch.ones(2, 4, dtype=torch.long)
-    mask[0, :2] = 0
-    fp = compute_fingerprint(acts, attention_mask=mask)
-    expected = (0 * 16 + 5.0 * 48) / 48
-    assert abs(fp - expected) < 1e-6
+def test_fingerprint_no_mask_values() -> None:
+    pooled = {0: torch.ones(2, 8)}
+    fp = compute_fingerprint(pooled)
+    assert torch.allclose(fp, torch.ones(2, 8))
 
 
-def test_fingerprint_multi_layer() -> None:
-    acts = {
-        0: torch.full((1, 2, 4), 2.0),
-        1: torch.full((1, 2, 4), 6.0),
+def test_fingerprint_multi_layer_shape() -> None:
+    pooled = {
+        0: torch.full((3, 4), 2.0),
+        1: torch.full((3, 4), 6.0),
     }
-    fp = compute_fingerprint(acts, attention_mask=None)
-    assert abs(fp - 4.0) < 1e-6
+    fp = compute_fingerprint(pooled)
+    assert fp.shape == (3, 8)
+
+
+def test_fingerprint_multi_layer_concat() -> None:
+    pooled = {
+        0: torch.full((1, 4), 2.0),
+        1: torch.full((1, 4), 6.0),
+    }
+    fp = compute_fingerprint(pooled)
+    expected = torch.tensor([[2.0, 2.0, 2.0, 2.0, 6.0, 6.0, 6.0, 6.0]])
+    assert torch.allclose(fp, expected)
 
 
 def test_fingerprint_empty() -> None:
-    fp = compute_fingerprint({}, attention_mask=None)
-    assert fp == 0.0
+    fp = compute_fingerprint({})
+    assert fp.numel() == 0
 
 
 def test_fingerprint_deterministic() -> None:
     torch.manual_seed(42)
-    acts = {0: torch.randn(8, 16, 32)}
-    fp1 = compute_fingerprint(acts, attention_mask=None)
-    fp2 = compute_fingerprint(acts, attention_mask=None)
-    assert fp1 == fp2
-    assert math.isfinite(fp1)
+    pooled = {0: torch.randn(8, 32)}
+    fp1 = compute_fingerprint(pooled)
+    fp2 = compute_fingerprint(pooled)
+    assert torch.equal(fp1, fp2)


### PR DESCRIPTION
## Summary

- **#20 — OOM fix**: `_FingerprintCapture` now pools on-the-fly during `on_batch` (masked-mean across positions), storing `[N, H]` per layer instead of `[N, S, H]`. Memory drops from O(N × S × L × H) to O(N × L × H) — the difference between 1.37 TB and 5.2 GB at 70B × 4096 × 256 × 80 layers.
- **#19 — Return contract**: `compute_fingerprint` returns `[N, L*H]` tensor (not scalar float), matching the harness's `cosine_similarity(ref.fingerprint.flatten(1), ...)` call site. Peak VRAM now reported in GB (not raw bytes).
- Progress enabled on all sweeps per project convention.

Closes #19
Closes #20

## Test plan

- [x] Unit tests: `compute_fingerprint` returns correct shape, values, handles empty/multi-layer/determinism
- [x] Integration tests: contract tuple types and shapes, fingerprint stability across calls, mask affects fingerprint, attention mask shape
- [x] Full CI suite passes (65 unit tests)
- [x] Lint (`ruff`) and type check (`mypy`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)