### PR TITLE
Add posix_fadvise(DONTNEED) on safetensors shards after layer unload

### DIFF
--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -12,6 +12,7 @@ from torch import Tensor, nn
 from fpwap.buffer import ResidualBuffer
 from fpwap.callbacks.base import Callback
 from fpwap.loader import (
+    ShardPageAdvisor,
     _load_layer,
     _load_named_param,
     _unload_layer,
@@ -279,6 +280,7 @@ class _OffloadStreamer(_LayerStreamer):
         self._loader = OffloadedWeightsLoader(index=accel_index)
         self._accel_index = accel_index
         self.last_load_bytes = 0
+        self._advisor = ShardPageAdvisor(accel_index)
         # Single-worker pool: next layer's load runs on a worker thread so
         # safetensors read + H2D overlap with the main thread's compute on
         # the current layer. Modern GPUs have a separate copy engine, so
@@ -312,7 +314,13 @@ class _OffloadStreamer(_LayerStreamer):
     def unload_layer(
         self, model: nn.Module, layer_idx: int, plumbing: ModelPlumbing
     ) -> None:
+        prefix = plumbing.layer_prefix(layer_idx)
+        layer = plumbing.layer_modules(model)[layer_idx]
+        weight_names = [
+            f"{prefix}.{rel}" for rel, _ in layer.named_parameters()
+        ]
         _unload_layer(model, layer_idx, plumbing)
+        self._advisor.advise_dontneed(weight_names)
 
     def prefetch_load(
         self, model: nn.Module, layer_idx: int, plumbing: ModelPlumbing

--- a/src/fpwap/loader.py
+++ b/src/fpwap/loader.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import struct
 import time
 from pathlib import Path
 from typing import Any
@@ -9,6 +11,8 @@ import torch
 from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from torch import nn
+
+_HAS_POSIX_FADVISE = hasattr(os, "posix_fadvise")
 
 
 def resolve_snapshot_dir(model: str) -> Path:
@@ -268,3 +272,81 @@ def _unload_layer(model: nn.Module, layer_idx: int, plumbing: Any) -> None:
     layer = plumbing.layer_modules(model)[layer_idx]
     for rel_name, _ in list(layer.named_parameters()):
         set_module_tensor_to_device(layer, rel_name, "meta")
+
+
+def _parse_safetensors_offsets(path: str) -> dict[str, tuple[int, int]]:
+    """Parse a safetensors header to get absolute byte offsets per tensor.
+
+    Returns {tensor_name: (abs_start, abs_end)} where offsets are relative
+    to the start of the file (not the data region).
+    """
+    with open(path, "rb") as f:
+        header_size = struct.unpack("<Q", f.read(8))[0]
+        header_bytes = f.read(header_size)
+
+    data_start = 8 + header_size
+    header = json.loads(header_bytes)
+
+    offsets: dict[str, tuple[int, int]] = {}
+    for name, meta in header.items():
+        if name == "__metadata__":
+            continue
+        start, end = meta["data_offsets"]
+        offsets[name] = (data_start + start, data_start + end)
+    return offsets
+
+
+class ShardPageAdvisor:
+    """Advises the kernel about page cache for safetensors shards.
+
+    Uses posix_fadvise(DONTNEED) after a layer is unloaded so the kernel
+    can reclaim those pages for upcoming layers. On non-Linux platforms
+    (no posix_fadvise), all methods are silent no-ops.
+    """
+
+    def __init__(self, accel_index: dict[str, dict[str, Any]]) -> None:
+        self._offsets: dict[str, tuple[str, int, int]] = {}
+        if not _HAS_POSIX_FADVISE:
+            return
+
+        shard_paths: set[str] = set()
+        for entry in accel_index.values():
+            shard_paths.add(entry["safetensors_file"])
+
+        shard_offsets: dict[str, dict[str, tuple[int, int]]] = {}
+        for path in shard_paths:
+            shard_offsets[path] = _parse_safetensors_offsets(path)
+
+        for weight_name, entry in accel_index.items():
+            shard_path = entry["safetensors_file"]
+            st_name = entry["weight_name"]
+            if st_name in shard_offsets.get(shard_path, {}):
+                start, end = shard_offsets[shard_path][st_name]
+                self._offsets[weight_name] = (shard_path, start, end)
+
+    def _advise(self, weight_names: list[str], advice: int) -> None:
+        if not _HAS_POSIX_FADVISE:
+            return
+        by_shard: dict[str, list[tuple[int, int]]] = {}
+        for name in weight_names:
+            if name not in self._offsets:
+                continue
+            path, start, end = self._offsets[name]
+            by_shard.setdefault(path, []).append((start, end))
+
+        for path, ranges in by_shard.items():
+            try:
+                fd = os.open(path, os.O_RDONLY)
+                try:
+                    for start, end in ranges:
+                        os.posix_fadvise(fd, start, end - start, advice)
+                finally:
+                    os.close(fd)
+            except OSError:
+                pass
+
+    def advise_dontneed(self, weight_names: list[str]) -> None:
+        self._advise(weight_names, os.POSIX_FADV_DONTNEED)
+
+    def advise_willneed(self, weight_names: list[str]) -> None:
+        self._advise(weight_names, os.POSIX_FADV_WILLNEED)

--- a/tests/unit/test_shard_page_advisor.py
+++ b/tests/unit/test_shard_page_advisor.py
@@ -1,0 +1,190 @@
+"""Unit tests for ShardPageAdvisor and safetensors offset parsing — CI-safe."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+from fpwap.loader import ShardPageAdvisor, _parse_safetensors_offsets
+
+
+def _make_shard(tmp_path: Path, name: str = "model.safetensors") -> Path:
+    """Create a tiny safetensors shard with known tensors."""
+    tensors = {
+        "model.layers.0.self_attn.q_proj.weight": torch.zeros(4, 8, dtype=torch.bfloat16),
+        "model.layers.0.self_attn.v_proj.weight": torch.ones(4, 8, dtype=torch.bfloat16),
+        "model.layers.1.self_attn.q_proj.weight": torch.zeros(8, 8, dtype=torch.bfloat16),
+    }
+    path = tmp_path / name
+    save_file(tensors, path)
+    return path
+
+
+def _make_accel_index(shard_path: Path) -> dict[str, dict]:
+    """Build a minimal accel_index pointing at the given shard."""
+    return {
+        "model.layers.0.self_attn.q_proj.weight": {
+            "safetensors_file": str(shard_path),
+            "weight_name": "model.layers.0.self_attn.q_proj.weight",
+            "dtype": "bfloat16",
+            "shape": [4, 8],
+        },
+        "model.layers.0.self_attn.v_proj.weight": {
+            "safetensors_file": str(shard_path),
+            "weight_name": "model.layers.0.self_attn.v_proj.weight",
+            "dtype": "bfloat16",
+            "shape": [4, 8],
+        },
+        "model.layers.1.self_attn.q_proj.weight": {
+            "safetensors_file": str(shard_path),
+            "weight_name": "model.layers.1.self_attn.q_proj.weight",
+            "dtype": "bfloat16",
+            "shape": [8, 8],
+        },
+    }
+
+
+class TestParseSafetensorsOffsets:
+    def test_returns_offsets_for_all_tensors(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        offsets = _parse_safetensors_offsets(str(shard_path))
+        assert "model.layers.0.self_attn.q_proj.weight" in offsets
+        assert "model.layers.0.self_attn.v_proj.weight" in offsets
+        assert "model.layers.1.self_attn.q_proj.weight" in offsets
+
+    def test_offsets_are_within_file(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        file_size = shard_path.stat().st_size
+        offsets = _parse_safetensors_offsets(str(shard_path))
+        for _name, (start, end) in offsets.items():
+            assert start >= 0
+            assert end <= file_size
+            assert start < end
+
+    def test_offset_sizes_match_tensor_sizes(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        offsets = _parse_safetensors_offsets(str(shard_path))
+        # 4×8 bf16 = 64 bytes
+        start, end = offsets["model.layers.0.self_attn.q_proj.weight"]
+        assert end - start == 4 * 8 * 2
+        # 8×8 bf16 = 128 bytes
+        start, end = offsets["model.layers.1.self_attn.q_proj.weight"]
+        assert end - start == 8 * 8 * 2
+
+    def test_no_metadata_key(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        offsets = _parse_safetensors_offsets(str(shard_path))
+        assert "__metadata__" not in offsets
+
+
+class TestShardPageAdvisor:
+    def test_construction_builds_offset_map(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        index = _make_accel_index(shard_path)
+        advisor = ShardPageAdvisor(index)
+        assert len(advisor._offsets) == 3
+
+    def test_advise_dontneed_calls_posix_fadvise(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        index = _make_accel_index(shard_path)
+        advisor = ShardPageAdvisor(index)
+
+        with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
+            advisor.advise_dontneed([
+                "model.layers.0.self_attn.q_proj.weight",
+                "model.layers.0.self_attn.v_proj.weight",
+            ])
+            assert mock_fadvise.call_count == 2
+            for call in mock_fadvise.call_args_list:
+                fd, offset, length, advice = call.args
+                assert advice == os.POSIX_FADV_DONTNEED
+                assert length > 0
+
+    def test_advise_willneed_calls_posix_fadvise(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        index = _make_accel_index(shard_path)
+        advisor = ShardPageAdvisor(index)
+
+        with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
+            advisor.advise_willneed([
+                "model.layers.1.self_attn.q_proj.weight",
+            ])
+            assert mock_fadvise.call_count == 1
+            _, _, _, advice = mock_fadvise.call_args.args
+            assert advice == os.POSIX_FADV_WILLNEED
+
+    def test_unknown_weight_name_is_noop(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        index = _make_accel_index(shard_path)
+        advisor = ShardPageAdvisor(index)
+
+        with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
+            advisor.advise_dontneed(["nonexistent.weight"])
+            mock_fadvise.assert_not_called()
+
+    def test_noop_when_posix_fadvise_unavailable(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        index = _make_accel_index(shard_path)
+
+        with patch("fpwap.loader._HAS_POSIX_FADVISE", False):
+            advisor = ShardPageAdvisor(index)
+            assert len(advisor._offsets) == 0
+            advisor.advise_dontneed([
+                "model.layers.0.self_attn.q_proj.weight",
+            ])
+
+    def test_oserror_is_silenced(self, tmp_path: Path) -> None:
+        shard_path = _make_shard(tmp_path)
+        index = _make_accel_index(shard_path)
+        advisor = ShardPageAdvisor(index)
+
+        with patch(
+            "fpwap.loader.os.posix_fadvise",
+            side_effect=OSError("not supported"),
+        ):
+            advisor.advise_dontneed([
+                "model.layers.0.self_attn.q_proj.weight",
+            ])
+
+    def test_multi_shard_groups_by_file(self, tmp_path: Path) -> None:
+        shard1 = tmp_path / "shard1.safetensors"
+        shard2 = tmp_path / "shard2.safetensors"
+        save_file(
+            {"w0": torch.zeros(2, 2, dtype=torch.bfloat16)},
+            shard1,
+        )
+        save_file(
+            {"w1": torch.zeros(4, 4, dtype=torch.bfloat16)},
+            shard2,
+        )
+        index = {
+            "w0": {
+                "safetensors_file": str(shard1),
+                "weight_name": "w0",
+                "dtype": "bfloat16",
+                "shape": [2, 2],
+            },
+            "w1": {
+                "safetensors_file": str(shard2),
+                "weight_name": "w1",
+                "dtype": "bfloat16",
+                "shape": [4, 4],
+            },
+        }
+        advisor = ShardPageAdvisor(index)
+
+        fds_opened: list[str] = []
+        original_open = os.open
+
+        def tracking_open(path, flags, *args, **kwargs):
+            fds_opened.append(path)
+            return original_open(path, flags, *args, **kwargs)
+
+        with patch("fpwap.loader.os.open", side_effect=tracking_open):
+            with patch("fpwap.loader.os.posix_fadvise"):
+                advisor.advise_dontneed(["w0", "w1"])
+
+        assert len(fds_opened) == 2


### PR DESCRIPTION
## Summary

- Parses safetensors shard headers at `_OffloadStreamer` construction to build a weight→byte-range mapping
- After each layer is unloaded back to meta device, calls `posix_fadvise(POSIX_FADV_DONTNEED)` on the exact byte ranges of that layer's weight tensors
- On hosts where model size exceeds RAM (e.g. 132 GB 70B on 124 GB), this frees page cache space for upcoming layers instead of relying on LRU eviction that retains already-processed layers
- Silent no-op on non-Linux platforms (macOS, Windows)
- `OSError` from unsupported filesystems is caught and silenced
- Also exposes `advise_willneed` for future prefetch optimizations

Closes #25

## Test plan

- [x] 11 unit tests for `_parse_safetensors_offsets` and `ShardPageAdvisor` (CI-safe, no GPU)
- [x] `ruff check` and `mypy` pass
- [x] Full unit + integration suite passes (85 tests)
- [ ] Benchmark on 70B cold-start: max `timing.load_s` should decrease from 2.308s baseline
- [ ] Benchmark on cache-resident host: no throughput regression
- [ ] Per-layer load time comparison (before vs after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)