### PR TITLE
Add padding='bucketed' for variable-length input batches

### DIFF
--- a/scripts/bench_bucketed_padding.py
+++ b/scripts/bench_bucketed_padding.py
@@ -143,7 +143,7 @@ def main():
     speedup = wall_fixed / wall_bucketed if wall_bucketed > 0 else float("inf")
     token_reduction = 1.0 - prof_bucketed.total_tokens / prof_fixed.total_tokens
     print(f"\n{'='*60}")
-    print(f"  Summary")
+    print("  Summary")
     print(f"{'='*60}")
     print(f"  speedup:          {speedup:.2f}×")
     print(f"  token reduction:  {token_reduction*100:.1f}%")

--- a/scripts/bench_bucketed_padding.py
+++ b/scripts/bench_bucketed_padding.py
@@ -1,0 +1,157 @@
+"""Benchmark: fixed vs bucketed padding on mixed-length datasets.
+
+Demonstrates the compute savings from padding='bucketed' on a bimodal
+sequence-length distribution (the "alpaca ~50 + ai_liar 400+" use case
+from issue #10).
+
+Usage:
+    uv run scripts/bench_bucketed_padding.py
+    uv run scripts/bench_bucketed_padding.py --n-short 100 --n-long 100
+    uv run scripts/bench_bucketed_padding.py --n-layers 6 --hidden 128
+"""
+from __future__ import annotations
+
+import argparse
+import time
+import warnings
+
+import torch
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from fpwap import Callback, Sweep
+from fpwap.types import BatchResult, HookName
+
+
+class NullCapture(Callback):
+    phase = "read"
+    target_layers = "all"
+    target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+    def __init__(self) -> None:
+        self.touches = 0
+
+    def on_batch(
+        self, layer_idx: int, hook: HookName,
+        acts: torch.Tensor, sample_ids: torch.Tensor,
+    ) -> BatchResult:
+        self.touches += int(acts.shape[0])
+        return None
+
+
+def build_mixed_dataset(
+    n_short: int, n_long: int, short_range: tuple[int, int],
+    long_range: tuple[int, int], max_seq: int, vocab: int,
+) -> list[dict[str, torch.Tensor]]:
+    torch.manual_seed(42)
+    items: list[dict[str, torch.Tensor]] = []
+    for low, high, count in [
+        (short_range[0], short_range[1], n_short),
+        (long_range[0], long_range[1], n_long),
+    ]:
+        for _ in range(count):
+            L = torch.randint(low, high + 1, (1,)).item()
+            ids = torch.full((1, max_seq), 0, dtype=torch.long)
+            mask = torch.zeros((1, max_seq), dtype=torch.long)
+            ids[0, max_seq - L:] = torch.randint(1, vocab, (L,))
+            mask[0, max_seq - L:] = 1
+            items.append({"input_ids": ids, "attention_mask": mask})
+    return items
+
+
+def run_sweep(model, items, seq_len, padding, label):
+    cap = NullCapture()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        sweep = Sweep(
+            model=model,
+            dataset=items,
+            seq_len=seq_len,
+            callbacks=[cap],
+            transport_dtype=torch.float32,
+            padding=padding,
+            apply_final_norm=False,
+            progress=False,
+        )
+        t0 = time.perf_counter()
+        result = sweep.run()
+        wall = time.perf_counter() - t0
+
+    prof = result.profile
+    print(f"\n{'='*60}")
+    print(f"  {label}")
+    print(f"{'='*60}")
+    print(f"  wall clock:   {wall:.4f}s")
+    print(f"  tokens:       {prof.total_tokens:,}")
+    print(f"  throughput:   {prof.throughput_tok_per_s():,.0f} tok/s")
+    print(f"  embed:        {prof.embed_s:.4f}s")
+    print(f"  loop:         {prof.loop_s:.4f}s")
+    print(f"  cb touches:   {cap.touches}")
+    return wall, prof
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--n-short", type=int, default=50)
+    p.add_argument("--n-long", type=int, default=50)
+    p.add_argument("--short-min", type=int, default=30)
+    p.add_argument("--short-max", type=int, default=70)
+    p.add_argument("--long-min", type=int, default=350)
+    p.add_argument("--long-max", type=int, default=450)
+    p.add_argument("--max-seq", type=int, default=512)
+    p.add_argument("--vocab", type=int, default=256)
+    p.add_argument("--hidden", type=int, default=64)
+    p.add_argument("--n-layers", type=int, default=4)
+    p.add_argument("--n-heads", type=int, default=4)
+    args = p.parse_args()
+
+    config = GPT2Config(
+        vocab_size=args.vocab,
+        n_positions=args.max_seq,
+        n_embd=args.hidden,
+        n_layer=args.n_layers,
+        n_head=args.n_heads,
+    )
+    torch.manual_seed(0)
+    model = GPT2LMHeadModel(config)
+    model.eval()
+
+    items = build_mixed_dataset(
+        args.n_short, args.n_long,
+        (args.short_min, args.short_max),
+        (args.long_min, args.long_max),
+        args.max_seq, args.vocab,
+    )
+    n_total = len(items)
+    real_lengths = [it["attention_mask"].sum().item() for it in items]
+    avg_len = sum(real_lengths) / len(real_lengths)
+    print(f"\nDataset: {n_total} items, max_seq={args.max_seq}")
+    print(f"  short: {args.n_short} items, lengths {args.short_min}-{args.short_max}")
+    print(f"  long:  {args.n_long} items, lengths {args.long_min}-{args.long_max}")
+    print(f"  avg real length: {avg_len:.1f} / {args.max_seq} "
+          f"({avg_len/args.max_seq*100:.0f}% utilization)")
+    print(f"  wasted tokens (fixed): {n_total * args.max_seq - sum(real_lengths):,}")
+
+    print(f"\nModel: GPT-2 config, {args.n_layers}L × {args.hidden}H × {args.n_heads}heads")
+
+    wall_fixed, prof_fixed = run_sweep(
+        model, items, args.max_seq, "fixed", "padding='fixed' (pad-to-max)"
+    )
+    wall_bucketed, prof_bucketed = run_sweep(
+        model, items, args.max_seq, "bucketed", "padding='bucketed'"
+    )
+
+    speedup = wall_fixed / wall_bucketed if wall_bucketed > 0 else float("inf")
+    token_reduction = 1.0 - prof_bucketed.total_tokens / prof_fixed.total_tokens
+    print(f"\n{'='*60}")
+    print(f"  Summary")
+    print(f"{'='*60}")
+    print(f"  speedup:          {speedup:.2f}×")
+    print(f"  token reduction:  {token_reduction*100:.1f}%")
+    print(f"  fixed wall:       {wall_fixed:.4f}s")
+    print(f"  bucketed wall:    {wall_bucketed:.4f}s")
+    print(f"  fixed tokens:     {prof_fixed.total_tokens:,}")
+    print(f"  bucketed tokens:  {prof_bucketed.total_tokens:,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -27,6 +27,7 @@ from fpwap.types import (
     Emit,
     HookName,
     LoadingStrategy,
+    PaddingMode,
     WriteBack,
 )
 
@@ -355,6 +356,130 @@ def _stack_field(items: list[Any], key: str) -> Tensor:
     return torch.cat(parts, dim=0)
 
 
+@dataclass
+class _Segment:
+    """A group of items with the same padded seq_len for the engine loop."""
+
+    seq_len: int
+    items: list[Any]
+    orig_indices: list[int]
+    buffer: ResidualBuffer
+    mask_buffer: Tensor | None
+    mb_size: int
+
+    @property
+    def n_samples(self) -> int:
+        return len(self.items)
+
+
+def _next_power_of_2(n: int) -> int:
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+def _detect_left_padding(items: list[Any]) -> bool:
+    for item in items:
+        mask = item["attention_mask"]
+        if isinstance(mask, Tensor):
+            if mask.dim() == 2:
+                mask = mask.squeeze(0)
+            real_len = int(mask.sum().item())
+            if real_len < mask.shape[0]:
+                return int(mask[0].item()) == 0
+    return True
+
+
+def _trim_to_length(item: dict[str, Any], target_len: int, left_padded: bool) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, val in item.items():
+        if key not in ("input_ids", "attention_mask") or not isinstance(val, Tensor):
+            result[key] = val
+            continue
+        t = val
+        was_2d = t.dim() == 2
+        if was_2d:
+            t = t.squeeze(0)
+        cur = t.shape[0]
+        if cur > target_len:
+            t = t[-target_len:] if left_padded else t[:target_len]
+        elif cur < target_len:
+            pad = torch.zeros(target_len - cur, dtype=t.dtype, device=t.device)
+            t = torch.cat([pad, t]) if left_padded else torch.cat([t, pad])
+        if was_2d:
+            t = t.unsqueeze(0)
+        result[key] = t
+    return result
+
+
+def _build_bucketed_segments(
+    items: list[Any],
+    max_seq_len: int,
+    hidden: int,
+    transport_dtype: torch.dtype,
+    buf_device: torch.device,
+    mb_size_override: int | None,
+    config: Any,
+    exec_device: torch.device,
+) -> list[_Segment]:
+    real_lengths: list[int] = []
+    for item in items:
+        mask = item["attention_mask"]
+        if isinstance(mask, Tensor):
+            if mask.dim() == 2:
+                mask = mask.squeeze(0)
+            real_lengths.append(int(mask.sum().item()))
+        else:
+            real_lengths.append(max_seq_len)
+
+    left_padded = _detect_left_padding(items)
+
+    bucket_assign: dict[int, list[tuple[int, Any]]] = {}
+    for orig_idx, (item, rl) in enumerate(zip(items, real_lengths)):
+        bseq = min(_next_power_of_2(max(rl, 16)), max_seq_len)
+        bucket_assign.setdefault(bseq, []).append((orig_idx, item))
+
+    segments: list[_Segment] = []
+    for bseq in sorted(bucket_assign.keys()):
+        entries = bucket_assign[bseq]
+        orig_indices = [e[0] for e in entries]
+        trimmed_items = [_trim_to_length(e[1], bseq, left_padded) for e in entries]
+        n = len(trimmed_items)
+
+        buf = ResidualBuffer(n, bseq, hidden, transport_dtype, buf_device)
+        pin = buf_device.type == "cpu" and torch.cuda.is_available()
+        mask_buf = torch.zeros(
+            (n, bseq), dtype=torch.int64, device=buf_device, pin_memory=pin,
+        )
+
+        if mb_size_override is not None:
+            seg_mb = mb_size_override
+        else:
+            if isinstance(buf_device, torch.device):
+                buf_on_gpu = buf_device.type == "cuda"
+            else:
+                buf_on_gpu = "cuda" in str(buf_device)
+            seg_mb = estimate_max_microbatch(
+                config=config,
+                n_samples=n,
+                seq_len=bseq,
+                transport_dtype=transport_dtype,
+                exec_device=exec_device,
+                buf_on_gpu=buf_on_gpu,
+            )
+
+        segments.append(_Segment(
+            seq_len=bseq,
+            items=trimmed_items,
+            orig_indices=orig_indices,
+            buffer=buf,
+            mask_buffer=mask_buf,
+            mb_size=seg_mb,
+        ))
+
+    return segments
+
+
 def _run_naive_baseline(
     model: nn.Module,
     plumbing: ModelPlumbing,
@@ -493,6 +618,7 @@ class Sweep:
         execution_device: torch.device | str | None = None,
         buffer_device: torch.device | str | None = None,
         apply_final_norm: bool = True,
+        padding: PaddingMode = "fixed",
         _accel_index: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         self.model = model
@@ -509,6 +635,7 @@ class Sweep:
         self.snapshot_dir = snapshot_dir
         self.offload_dir = offload_dir
         self.apply_final_norm = apply_final_norm
+        self.padding: PaddingMode = padding
         self._accel_index = _accel_index
         self.execution_device = (
             torch.device(execution_device) if execution_device is not None else None
@@ -673,6 +800,13 @@ class Sweep:
                 "would require running cpu_offload in parallel and isn't wired. "
                 "For streaming correctness, see tests/gpu/test_streaming_bit_exact.py."
             )
+        if self.verify and self.padding == "bucketed":
+            raise NotImplementedError(
+                "verify=True is not supported with padding='bucketed'. "
+                "Bucketed padding uses per-bucket seq_len which changes the "
+                "naive baseline shape. Use the dedicated bucketed correctness "
+                "tests instead."
+            )
         t0_run = time.perf_counter_ns()
         model, streamer, setup_timing = self._resolve_model_and_streamer()
         model.eval()  # fpwap is inference-only; dropout/etc. must be off.
@@ -747,29 +881,62 @@ class Sweep:
             hidden=hidden,
             transport_dtype=self.transport_dtype,
         )
-        buffer = ResidualBuffer(
-            n_samples=n_samples,
-            seq_len=self.seq_len,
-            hidden=hidden,
-            dtype=self.transport_dtype,
-            device=buf_device,
-        )
 
-        # Optional parallel mask buffer: (N, seq) int8 when any item carries
-        # attention_mask, else None. Stored once; reused every layer so the
-        # 2D→additive conversion happens inside layer_forward per microbatch.
         has_mask = _has_attention_mask(items)
-        mask_pin = buf_device.type == "cpu" and torch.cuda.is_available()
-        mask_buffer: Tensor | None = (
-            torch.zeros(
-                (n_samples, self.seq_len),
-                dtype=torch.int64,
-                device=buf_device,
-                pin_memory=mask_pin,
+
+        # Build segments: one per bucket in bucketed mode, one total in fixed.
+        if self.padding == "bucketed":
+            if not has_mask:
+                raise ValueError(
+                    "padding='bucketed' requires attention_mask on all dataset "
+                    "items to determine real sequence lengths. Either add "
+                    "attention_mask or use padding='fixed'."
+                )
+            if plumbing.uses_learned_positions:
+                import warnings
+
+                warnings.warn(
+                    "padding='bucketed' with learned positional embeddings "
+                    f"({type(plumbing).__name__}): real tokens receive different "
+                    "position IDs than with padding='fixed'. Outputs will differ "
+                    "from fixed padding at positions where the bucket seq_len "
+                    "differs from the original seq_len. For RoPE models (Llama, "
+                    "Mistral), this is not an issue.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            mb_override: int | None = None if self.microbatch_size == "auto" else mb_size
+            segments = _build_bucketed_segments(
+                items, self.seq_len, hidden, self.transport_dtype,
+                buf_device, mb_override, config, exec_device,
             )
-            if has_mask
-            else None
-        )
+        else:
+            buffer = ResidualBuffer(
+                n_samples=n_samples,
+                seq_len=self.seq_len,
+                hidden=hidden,
+                dtype=self.transport_dtype,
+                device=buf_device,
+            )
+            mask_pin = buf_device.type == "cpu" and torch.cuda.is_available()
+            mask_buffer: Tensor | None = (
+                torch.zeros(
+                    (n_samples, self.seq_len),
+                    dtype=torch.int64,
+                    device=buf_device,
+                    pin_memory=mask_pin,
+                )
+                if has_mask
+                else None
+            )
+            segments = [_Segment(
+                seq_len=self.seq_len,
+                items=items,
+                orig_indices=list(range(n_samples)),
+                buffer=buffer,
+                mask_buffer=mask_buffer,
+                mb_size=mb_size,
+            )]
 
         # Emit sink: storage backend (disk) if wired, else in-memory.
         emits_sink: dict[tuple[int, str], list[tuple[Tensor, Tensor]]] = {}
@@ -787,15 +954,18 @@ class Sweep:
         # Pass 0: embedding over the whole dataset. Contiguous write_slice
         # into the pinned CPU buffer goes through the CUDA copy engine.
         with torch.no_grad():
-            for start in range(0, n_samples, mb_size):
-                stop = min(start + mb_size, n_samples)
-                input_ids = _stack_field(items[start:stop], "input_ids").to(exec_device)
-                embedded = plumbing.embed(model, input_ids)
-                buffer.write_slice(start, stop, embedded)
-                if mask_buffer is not None:
-                    mask_buffer[start:stop] = _stack_field(
-                        items[start:stop], "attention_mask"
-                    ).to(dtype=torch.int64)
+            for seg in segments:
+                for start in range(0, seg.n_samples, seg.mb_size):
+                    stop = min(start + seg.mb_size, seg.n_samples)
+                    input_ids = _stack_field(
+                        seg.items[start:stop], "input_ids"
+                    ).to(exec_device)
+                    embedded = plumbing.embed(model, input_ids)
+                    seg.buffer.write_slice(start, stop, embedded)
+                    if seg.mask_buffer is not None:
+                        seg.mask_buffer[start:stop] = _stack_field(
+                            seg.items[start:stop], "attention_mask"
+                        ).to(dtype=torch.int64)
         if exec_device.type == "cuda":
             torch.cuda.synchronize()
         embed_s = (time.perf_counter_ns() - t0_embed) / 1e9
@@ -894,127 +1064,124 @@ class Sweep:
             for cb in self.callbacks:
                 cb.on_layer_start(layer_idx)
 
-            n_batches = (n_samples + mb_size - 1) // mb_size
+            n_batches = sum(
+                (seg.n_samples + seg.mb_size - 1) // seg.mb_size
+                for seg in segments
+            )
             _emit_progress("layer_start", layer_idx, 0, n_batches)
             block = layer_modules[layer_idx]
-            for start in range(0, n_samples, mb_size):
-                stop = min(start + mb_size, n_samples)
-                sample_ids_exec = torch.arange(start, stop, device=exec_device)
+            batch_counter = 0
+            for seg in segments:
+                for start in range(0, seg.n_samples, seg.mb_size):
+                    stop = min(start + seg.mb_size, seg.n_samples)
+                    sample_ids_exec = torch.tensor(
+                        seg.orig_indices[start:stop],
+                        device=exec_device,
+                        dtype=torch.long,
+                    )
 
-                t_fwd = time.perf_counter_ns()
-                with torch.no_grad():
-                    # Contiguous slice reads exploit the pinned CPU buffer for
-                    # async H2D; index reads (buffer[tensor]) would allocate a
-                    # non-pinned intermediate and block the transfer.
-                    hidden_states = buffer.read_slice(start, stop).to(
-                        exec_device, non_blocking=True
-                    )
-                    mb_mask = (
-                        mask_buffer[start:stop].to(exec_device, non_blocking=True)
-                        if mask_buffer is not None
-                        else None
-                    )
-                    if dispatch_residual_pre:
-                        hidden_states = self._dispatch_callbacks(
-                            layer_idx,
-                            "residual_pre",
+                    t_fwd = time.perf_counter_ns()
+                    with torch.no_grad():
+                        hidden_states = seg.buffer.read_slice(start, stop).to(
+                            exec_device, non_blocking=True
+                        )
+                        mb_mask = (
+                            seg.mask_buffer[start:stop].to(
+                                exec_device, non_blocking=True
+                            )
+                            if seg.mask_buffer is not None
+                            else None
+                        )
+                        if dispatch_residual_pre:
+                            hidden_states = self._dispatch_callbacks(
+                                layer_idx,
+                                "residual_pre",
+                                hidden_states,
+                                sample_ids_exec,
+                                emits_sink=emits_sink,
+                            )
+                        inline_dispatch = None
+                        if needs_inline_sublayer_dispatch:
+                            def _inline(
+                                hook_name: str,
+                                tensor: Tensor,
+                                _layer_idx: int = layer_idx,
+                                _sample_ids: Tensor = sample_ids_exec,
+                            ) -> Tensor:
+                                return self._dispatch_callbacks(
+                                    _layer_idx,
+                                    hook_name,  # type: ignore[arg-type]
+                                    tensor,
+                                    _sample_ids,
+                                    emits_sink=emits_sink,
+                                    write_allowed=True,
+                                )
+
+                            inline_dispatch = _inline
+
+                        hidden_states, extras = plumbing.layer_forward_with_hooks(
+                            model,
+                            block,
                             hidden_states,
+                            attention_mask=mb_mask,
+                            wanted_hooks=sub_hooks,
+                            dispatch_fn=inline_dispatch,
+                        )
+                    timing.forward_s += (time.perf_counter_ns() - t_fwd) / 1e9
+
+                    if final_norm is not None and layer_idx == n_layers - 1:
+                        hidden_states = final_norm(hidden_states)
+
+                    t_cb = time.perf_counter_ns()
+                    for sub_hook, sub_tensor in extras.items():
+                        self._dispatch_callbacks(
+                            layer_idx,
+                            sub_hook,  # type: ignore[arg-type]
+                            sub_tensor,
                             sample_ids_exec,
                             emits_sink=emits_sink,
+                            write_allowed=False,
                         )
-                    inline_dispatch = None
-                    if needs_inline_sublayer_dispatch:
-                        # Bind this microbatch's identifiers via default args
-                        # so the closure doesn't pick up later iterations'
-                        # values. Called synchronously inside plumbing for
-                        # each sub-layer hook that has callbacks wired.
-                        def _inline(
-                            hook_name: str,
-                            tensor: Tensor,
-                            _layer_idx: int = layer_idx,
-                            _sample_ids: Tensor = sample_ids_exec,
-                        ) -> Tensor:
-                            return self._dispatch_callbacks(
-                                _layer_idx,
-                                hook_name,  # type: ignore[arg-type]
-                                tensor,
-                                _sample_ids,
-                                emits_sink=emits_sink,
-                                write_allowed=True,
-                            )
-
-                        inline_dispatch = _inline
-
-                    hidden_states, extras = plumbing.layer_forward_with_hooks(
-                        model,
-                        block,
-                        hidden_states,
-                        attention_mask=mb_mask,
-                        wanted_hooks=sub_hooks,
-                        dispatch_fn=inline_dispatch,
-                    )
-                timing.forward_s += (time.perf_counter_ns() - t_fwd) / 1e9
-
-                # Last layer + apply_final_norm: apply the model's final
-                # layernorm so residual_post matches HF's output_hidden_states.
-                if final_norm is not None and layer_idx == n_layers - 1:
-                    hidden_states = final_norm(hidden_states)
-
-                t_cb = time.perf_counter_ns()
-                # Sub-layer extras that the plumbing didn't dispatch inline
-                # (pure-read case) go here as read-only. When inline dispatch
-                # was active, extras is empty by construction.
-                for sub_hook, sub_tensor in extras.items():
-                    self._dispatch_callbacks(
+                    hidden_states = self._dispatch_callbacks(
                         layer_idx,
-                        sub_hook,  # type: ignore[arg-type]
-                        sub_tensor,
+                        "residual_post",
+                        hidden_states,
                         sample_ids_exec,
                         emits_sink=emits_sink,
-                        write_allowed=False,
                     )
-                hidden_states = self._dispatch_callbacks(
-                    layer_idx,
-                    "residual_post",
-                    hidden_states,
-                    sample_ids_exec,
-                    emits_sink=emits_sink,
-                )
-                if verify_baseline is not None:
-                    expected = verify_baseline[layer_idx][start:stop].to(
-                        device=hidden_states.device, dtype=hidden_states.dtype
-                    )
-                    # On padded datasets, the pad positions are "don't care"
-                    # (HF's own output there is undefined); compare only at
-                    # real tokens, like tests/integration/test_padded_batch.py.
-                    if mb_mask is not None:
-                        m = mb_mask.bool().unsqueeze(-1)
-                        got_real = hidden_states.masked_select(m)
-                        exp_real = expected.masked_select(m)
-                        ok = torch.equal(got_real, exp_real)
-                    else:
-                        ok = torch.equal(hidden_states, expected)
-                    if not ok:
-                        diff = (hidden_states.float() - expected.float()).abs().max().item()
-                        raise RuntimeError(
-                            f"verify: layer {layer_idx} microbatch [{start}:{stop}] "
-                            f"diverged from naive baseline (max abs diff {diff}). "
-                            f"For bf16 this usually means microbatch_size != dataset size "
-                            f"(see bf16_microbatch_determinism); for fp32 it indicates "
-                            f"a plumbing bug."
+                    if verify_baseline is not None:
+                        expected = verify_baseline[layer_idx][start:stop].to(
+                            device=hidden_states.device, dtype=hidden_states.dtype
                         )
-                timing.callback_s += (time.perf_counter_ns() - t_cb) / 1e9
+                        if mb_mask is not None:
+                            m = mb_mask.bool().unsqueeze(-1)
+                            got_real = hidden_states.masked_select(m)
+                            exp_real = expected.masked_select(m)
+                            ok = torch.equal(got_real, exp_real)
+                        else:
+                            ok = torch.equal(hidden_states, expected)
+                        if not ok:
+                            diff = (hidden_states.float() - expected.float()).abs().max().item()
+                            raise RuntimeError(
+                                f"verify: layer {layer_idx} microbatch [{start}:{stop}] "
+                                f"diverged from naive baseline (max abs diff {diff}). "
+                                f"For bf16 this usually means microbatch_size != dataset "
+                                f"size (see bf16_microbatch_determinism); for fp32 it "
+                                f"indicates a plumbing bug."
+                            )
+                    timing.callback_s += (time.perf_counter_ns() - t_cb) / 1e9
 
-                t_w = time.perf_counter_ns()
-                buffer.write_slice(start, stop, hidden_states)
-                timing.write_s += (time.perf_counter_ns() - t_w) / 1e9
-                timing.bytes_buffer += hidden_states.element_size() * hidden_states.numel()
-                _emit_progress(
-                    "microbatch_end",
-                    layer_idx,
-                    start // mb_size + 1,
-                    n_batches,
-                )
+                    t_w = time.perf_counter_ns()
+                    seg.buffer.write_slice(start, stop, hidden_states)
+                    timing.write_s += (time.perf_counter_ns() - t_w) / 1e9
+                    timing.bytes_buffer += hidden_states.element_size() * hidden_states.numel()
+                    batch_counter += 1
+                    _emit_progress(
+                        "microbatch_end",
+                        layer_idx,
+                        batch_counter,
+                        n_batches,
+                    )
 
             # Drain pending async D2H writes so the next layer's reads see
             # a coherent buffer. One sync per layer is negligible vs the
@@ -1060,7 +1227,9 @@ class Sweep:
         teardown_s = (time.perf_counter_ns() - t0_teardown) / 1e9
 
         profile.total_wall_s = (time.perf_counter_ns() - t0_run) / 1e9
-        profile.total_tokens = n_samples * self.seq_len
+        profile.total_tokens = sum(
+            seg.n_samples * seg.seq_len for seg in segments
+        )
         profile.setup = setup_timing
         profile.embed_s = embed_s
         profile.loop_s = loop_s

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -435,7 +435,7 @@ def _build_bucketed_segments(
     left_padded = _detect_left_padding(items)
 
     bucket_assign: dict[int, list[tuple[int, Any]]] = {}
-    for orig_idx, (item, rl) in enumerate(zip(items, real_lengths)):
+    for orig_idx, (item, rl) in enumerate(zip(items, real_lengths, strict=True)):
         bseq = min(_next_power_of_2(max(rl, 16)), max_seq_len)
         bucket_assign.setdefault(bseq, []).append((orig_idx, item))
 

--- a/src/fpwap/models/base.py
+++ b/src/fpwap/models/base.py
@@ -11,6 +11,8 @@ DispatchFn = Callable[[str, Tensor], Tensor]
 class ModelPlumbing(Protocol):
     """Per-family hook plumbing. Implementations live in fpwap/models/<family>.py."""
 
+    uses_learned_positions: bool
+
     def matches(self, model: nn.Module) -> bool: ...
 
     def layer_modules(self, model: nn.Module) -> Sequence[nn.Module]: ...

--- a/src/fpwap/models/gpt2.py
+++ b/src/fpwap/models/gpt2.py
@@ -10,6 +10,8 @@ from torch import Tensor, nn
 class GPT2Plumbing:
     """Hook plumbing for HuggingFace GPT-2 family (`GPT2LMHeadModel`, `GPT2Model`)."""
 
+    uses_learned_positions: bool = True
+
     def matches(self, model: nn.Module) -> bool:
         transformer = getattr(model, "transformer", None)
         return transformer is not None and hasattr(transformer, "h") and hasattr(transformer, "wte")

--- a/src/fpwap/models/llama.py
+++ b/src/fpwap/models/llama.py
@@ -22,6 +22,8 @@ class LlamaPlumbing:
     on top of the standard hidden_states + attention_mask signature.
     """
 
+    uses_learned_positions: bool = False
+
     def matches(self, model: nn.Module) -> bool:
         inner = getattr(model, "model", None)
         return (

--- a/src/fpwap/types.py
+++ b/src/fpwap/types.py
@@ -8,6 +8,7 @@ from torch import Tensor
 
 HookName = Literal["residual_pre", "residual_post", "attn_out", "mlp_out"]
 LoadingStrategy = Literal["cpu_offload", "disk_offload", "mmap_from_cache"]
+PaddingMode = Literal["fixed", "bucketed"]
 Phase = Literal["read", "write", "read_after_write"]
 
 

--- a/tests/integration/test_bucketed_padding.py
+++ b/tests/integration/test_bucketed_padding.py
@@ -1,0 +1,263 @@
+"""Bucketed padding: variable-length sequences grouped by real length.
+
+Verifies that padding='bucketed' produces correct activations at real
+(unmasked) positions. Each bucket's output is compared against HF's
+naive forward on the same trimmed inputs — this is the true correctness
+baseline (not the fixed-padding forward, which uses different positions).
+
+Covers issue #10: relax fixed seq_len assumption.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+SEED = 42
+SEQ_LEN = 64
+HIDDEN = 16
+N_LAYERS = 2
+VOCAB = 32
+PAD_TOKEN = 0
+N_SHORT = 4
+N_LONG = 4
+N_SAMPLES = N_SHORT + N_LONG
+
+
+def _tiny_gpt2() -> torch.nn.Module:
+    from transformers import GPT2Config, GPT2LMHeadModel
+
+    config = GPT2Config(
+        vocab_size=VOCAB,
+        n_positions=SEQ_LEN,
+        n_embd=HIDDEN,
+        n_layer=N_LAYERS,
+        n_head=2,
+    )
+    torch.manual_seed(SEED)
+    model = GPT2LMHeadModel(config)
+    model.eval()
+    return model
+
+
+def _mixed_length_dataset() -> list[dict[str, torch.Tensor]]:
+    """Left-padded dataset: 4 short (~8 tok) + 4 long (~48 tok) sequences."""
+    torch.manual_seed(SEED + 1)
+    short_lengths = [5, 7, 9, 11]
+    long_lengths = [40, 45, 50, 55]
+    all_lengths = short_lengths + long_lengths
+
+    items: list[dict[str, torch.Tensor]] = []
+    for L in all_lengths:
+        input_ids = torch.full((1, SEQ_LEN), PAD_TOKEN, dtype=torch.long)
+        attention_mask = torch.zeros((1, SEQ_LEN), dtype=torch.long)
+        input_ids[0, SEQ_LEN - L :] = torch.randint(1, VOCAB, (L,))
+        attention_mask[0, SEQ_LEN - L :] = 1
+        items.append({"input_ids": input_ids, "attention_mask": attention_mask})
+    return items
+
+
+@pytest.mark.integration
+
+def test_bucketed_padding_basic() -> None:
+    """padding='bucketed' runs to completion and returns per-sample activations."""
+    from fpwap import Callback, Sweep
+    from fpwap.types import BatchResult, HookName
+
+    model = _tiny_gpt2()
+    items = _mixed_length_dataset()
+
+    class Capture(Callback):
+        phase = "read"
+        target_layers = "all"
+        target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+        def __init__(self) -> None:
+            self.per_sample: dict[int, dict[int, torch.Tensor]] = {}
+
+        def on_batch(
+            self,
+            layer_idx: int,
+            hook: HookName,
+            acts: torch.Tensor,
+            sample_ids: torch.Tensor,
+        ) -> BatchResult:
+            for i, sid in enumerate(sample_ids.cpu().tolist()):
+                self.per_sample.setdefault(sid, {})[layer_idx] = (
+                    acts[i].detach().float().cpu()
+                )
+            return None
+
+    cap = Capture()
+    sweep = Sweep(
+        model=model,
+        dataset=items,
+        seq_len=SEQ_LEN,
+        callbacks=[cap],
+        transport_dtype=torch.float32,
+        padding="bucketed",
+        apply_final_norm=False,
+    )
+    result = sweep.run()
+
+    for i in range(N_SAMPLES):
+        assert i in cap.per_sample, f"sample {i} missing from output"
+        for layer in range(N_LAYERS):
+            assert layer in cap.per_sample[i], f"sample {i} missing layer {layer}"
+            acts = cap.per_sample[i][layer]
+            assert acts.shape[-1] == HIDDEN
+            assert torch.isfinite(acts).all()
+
+
+@pytest.mark.integration
+
+def test_bucketed_matches_per_bucket_naive() -> None:
+    """Each bucket's activations match HF's naive forward on the same trimmed inputs.
+
+    This is the real correctness guarantee: given the same (trimmed) input_ids
+    and attention_mask, fpwap's bucketed output equals HF's own forward at
+    every real (unmasked) position.
+    """
+    from fpwap import Callback, Sweep
+    from fpwap.types import BatchResult, HookName
+
+    model = _tiny_gpt2()
+    items = _mixed_length_dataset()
+
+    class Capture(Callback):
+        phase = "read"
+        target_layers = "all"
+        target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+        def __init__(self) -> None:
+            self.per_sample: dict[int, dict[int, torch.Tensor]] = {}
+
+        def on_batch(
+            self,
+            layer_idx: int,
+            hook: HookName,
+            acts: torch.Tensor,
+            sample_ids: torch.Tensor,
+        ) -> BatchResult:
+            for i, sid in enumerate(sample_ids.cpu().tolist()):
+                self.per_sample.setdefault(sid, {})[layer_idx] = (
+                    acts[i].detach().float().cpu()
+                )
+            return None
+
+    cap = Capture()
+    sweep = Sweep(
+        model=model,
+        dataset=items,
+        seq_len=SEQ_LEN,
+        callbacks=[cap],
+        transport_dtype=torch.float32,
+        padding="bucketed",
+        apply_final_norm=False,
+    )
+    sweep.run()
+
+    # Naive baseline: run each sample individually through HF at its own
+    # bucket-trimmed length. Compare at real positions.
+    def _next_po2(n: int) -> int:
+        return 1 << max(n - 1, 0).bit_length() if n > 1 else 1
+
+    for i, item in enumerate(items):
+        mask = item["attention_mask"].squeeze(0)
+        real_len = int(mask.sum().item())
+        bseq = min(_next_po2(max(real_len, 16)), SEQ_LEN)
+
+        # Trim (left-padded → take rightmost bseq tokens)
+        ids_trimmed = item["input_ids"][:, -bseq:]
+        mask_trimmed = item["attention_mask"][:, -bseq:]
+
+        # Naive HF forward on the trimmed input
+        captures: dict[int, torch.Tensor] = {}
+
+        def _make_hook(layer_idx: int):
+            def hook(_mod, _inp, out):
+                hidden = out[0] if isinstance(out, tuple) else out
+                captures[layer_idx] = hidden.detach().clone()
+
+            return hook
+
+        handles = [
+            block.register_forward_hook(_make_hook(li))
+            for li, block in enumerate(model.transformer.h)
+        ]
+        try:
+            with torch.no_grad():
+                model(input_ids=ids_trimmed, attention_mask=mask_trimmed)
+        finally:
+            for h in handles:
+                h.remove()
+
+        # Compare at real positions
+        mask_1d = mask_trimmed.squeeze(0).bool()
+        for layer_idx in range(N_LAYERS):
+            got = cap.per_sample[i][layer_idx]
+            expected = captures[layer_idx].squeeze(0).float()
+            got_real = got[mask_1d]
+            exp_real = expected[mask_1d]
+            max_diff = (got_real - exp_real).abs().max().item()
+            assert torch.allclose(got_real, exp_real, atol=1e-5, rtol=1e-5), (
+                f"sample {i} layer {layer_idx}: bucketed vs naive mismatch "
+                f"at real positions (max diff {max_diff})"
+            )
+
+
+@pytest.mark.integration
+
+def test_bucketed_warns_learned_positions() -> None:
+    """padding='bucketed' emits a UserWarning for GPT-2 (learned positional embeddings)."""
+    from fpwap import Callback, Sweep
+    from fpwap.types import HookName
+
+    model = _tiny_gpt2()
+    items = _mixed_length_dataset()
+
+    class Noop(Callback):
+        phase = "read"
+        target_layers = "all"
+        target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+    with pytest.warns(UserWarning, match="learned positional"):
+        sweep = Sweep(
+            model=model,
+            dataset=items,
+            seq_len=SEQ_LEN,
+            callbacks=[Noop()],
+            transport_dtype=torch.float32,
+            padding="bucketed",
+            apply_final_norm=False,
+        )
+        sweep.run()
+
+
+@pytest.mark.integration
+
+def test_bucketed_requires_attention_mask() -> None:
+    """padding='bucketed' raises ValueError when items lack attention_mask."""
+    from fpwap import Callback, Sweep
+    from fpwap.types import HookName
+
+    model = _tiny_gpt2()
+    items = [
+        {"input_ids": torch.randint(1, VOCAB, (1, SEQ_LEN))} for _ in range(4)
+    ]
+
+    class Noop(Callback):
+        phase = "read"
+        target_layers = "all"
+        target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+    sweep = Sweep(
+        model=model,
+        dataset=items,
+        seq_len=SEQ_LEN,
+        callbacks=[Noop()],
+        transport_dtype=torch.float32,
+        padding="bucketed",
+        apply_final_norm=False,
+    )
+    with pytest.raises(ValueError, match="attention_mask"):
+        sweep.run()

--- a/tests/integration/test_bucketed_padding.py
+++ b/tests/integration/test_bucketed_padding.py
@@ -97,7 +97,7 @@ def test_bucketed_padding_basic() -> None:
         padding="bucketed",
         apply_final_norm=False,
     )
-    result = sweep.run()
+    sweep.run()
 
     for i in range(N_SAMPLES):
         assert i in cap.per_sample, f"sample {i} missing from output"
@@ -173,10 +173,10 @@ def test_bucketed_matches_per_bucket_naive() -> None:
         # Naive HF forward on the trimmed input
         captures: dict[int, torch.Tensor] = {}
 
-        def _make_hook(layer_idx: int):
+        def _make_hook(layer_idx: int, _cap: dict = captures):  # noqa: B006
             def hook(_mod, _inp, out):
                 hidden = out[0] if isinstance(out, tuple) else out
-                captures[layer_idx] = hidden.detach().clone()
+                _cap[layer_idx] = hidden.detach().clone()
 
             return hook
 

--- a/tests/unit/test_bucketing.py
+++ b/tests/unit/test_bucketing.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import torch
 
 
-
 def test_next_power_of_2() -> None:
     from fpwap.engine import _next_power_of_2
 

--- a/tests/unit/test_bucketing.py
+++ b/tests/unit/test_bucketing.py
@@ -1,0 +1,124 @@
+"""Unit tests for bucket-building helpers (CI-safe, no GPU)."""
+from __future__ import annotations
+
+import torch
+
+
+
+def test_next_power_of_2() -> None:
+    from fpwap.engine import _next_power_of_2
+
+    assert _next_power_of_2(1) == 1
+    assert _next_power_of_2(2) == 2
+    assert _next_power_of_2(3) == 4
+    assert _next_power_of_2(5) == 8
+    assert _next_power_of_2(16) == 16
+    assert _next_power_of_2(17) == 32
+    assert _next_power_of_2(50) == 64
+    assert _next_power_of_2(400) == 512
+
+
+
+def test_detect_left_padding() -> None:
+    from fpwap.engine import _detect_left_padding
+
+    # Left-padded: mask starts with 0s
+    items = [
+        {
+            "attention_mask": torch.tensor([[0, 0, 0, 1, 1, 1]]),
+            "input_ids": torch.tensor([[0, 0, 0, 5, 6, 7]]),
+        }
+    ]
+    assert _detect_left_padding(items) is True
+
+    # Right-padded: mask ends with 0s
+    items = [
+        {
+            "attention_mask": torch.tensor([[1, 1, 1, 0, 0, 0]]),
+            "input_ids": torch.tensor([[5, 6, 7, 0, 0, 0]]),
+        }
+    ]
+    assert _detect_left_padding(items) is False
+
+    # No padding present (all 1s) — defaults to True
+    items = [
+        {
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 1]]),
+            "input_ids": torch.tensor([[1, 2, 3, 4, 5, 6]]),
+        }
+    ]
+    assert _detect_left_padding(items) is True
+
+
+
+def test_trim_to_length_left_padded() -> None:
+    from fpwap.engine import _trim_to_length
+
+    item = {
+        "input_ids": torch.tensor([[0, 0, 0, 5, 6, 7]]),
+        "attention_mask": torch.tensor([[0, 0, 0, 1, 1, 1]]),
+        "label": 42,
+    }
+    trimmed = _trim_to_length(item, 4, left_padded=True)
+
+    assert trimmed["input_ids"].shape == (1, 4)
+    assert trimmed["attention_mask"].shape == (1, 4)
+    assert torch.equal(trimmed["input_ids"], torch.tensor([[0, 5, 6, 7]]))
+    assert torch.equal(trimmed["attention_mask"], torch.tensor([[0, 1, 1, 1]]))
+    assert trimmed["label"] == 42  # non-tensor keys pass through
+
+
+
+def test_trim_to_length_right_padded() -> None:
+    from fpwap.engine import _trim_to_length
+
+    item = {
+        "input_ids": torch.tensor([[5, 6, 7, 0, 0, 0]]),
+        "attention_mask": torch.tensor([[1, 1, 1, 0, 0, 0]]),
+    }
+    trimmed = _trim_to_length(item, 4, left_padded=False)
+
+    assert torch.equal(trimmed["input_ids"], torch.tensor([[5, 6, 7, 0]]))
+    assert torch.equal(trimmed["attention_mask"], torch.tensor([[1, 1, 1, 0]]))
+
+
+
+def test_build_bucketed_segments() -> None:
+    from fpwap.engine import _build_bucketed_segments
+
+    max_seq = 64
+    hidden = 16
+    items = []
+    # 3 short (len ~5) + 3 long (len ~40) — should go into different buckets
+    for L in [4, 5, 6, 35, 40, 45]:
+        ids = torch.full((1, max_seq), 0, dtype=torch.long)
+        mask = torch.zeros((1, max_seq), dtype=torch.long)
+        ids[0, max_seq - L :] = torch.randint(1, 100, (L,))
+        mask[0, max_seq - L :] = 1
+        items.append({"input_ids": ids, "attention_mask": mask})
+
+    segments = _build_bucketed_segments(
+        items, max_seq, hidden, torch.float32, torch.device("cpu"),
+        mb_size_override=6, config=None, exec_device=torch.device("cpu"),
+    )
+
+    # Should produce at least 2 segments (short bucket and long bucket)
+    assert len(segments) >= 2
+
+    # All original indices covered exactly once
+    all_indices = []
+    for seg in segments:
+        all_indices.extend(seg.orig_indices)
+    assert sorted(all_indices) == list(range(len(items)))
+
+    # Each segment's buffer seq_len <= max_seq
+    for seg in segments:
+        assert seg.seq_len <= max_seq
+        assert seg.buffer.seq_len == seg.seq_len
+        assert seg.buffer.n_samples == seg.n_samples
+
+    # Short items got a shorter bucket than long items
+    short_seg = [s for s in segments if s.seq_len < 32]
+    long_seg = [s for s in segments if s.seq_len >= 32]
+    assert len(short_seg) >= 1, "expected a short-sequence bucket"
+    assert len(long_seg) >= 1, "expected a long-sequence bucket"


### PR DESCRIPTION
## Summary

Closes #10. Adds `padding="bucketed"` to `Sweep` for datasets with mixed sequence lengths.

- **Bucket building**: sorts items by real length (from `attention_mask`), groups into power-of-2 `seq_len` buckets, trims items per-bucket. Each bucket gets its own `ResidualBuffer` and mask buffer.
- **Engine loop**: loads layer weights once, iterates buckets × microbatches per layer. Same O(N_layers) weight I/O, less compute per layer for short-sequence buckets.
- **Auto microbatch**: when `microbatch_size="auto"`, estimates per-bucket (shorter sequences → larger microbatches → better GPU utilization).
- **Learned-position warning**: emits `UserWarning` for GPT-2-family models since bucket trimming changes position IDs. RoPE models (Llama, Mistral) are unaffected.
- `verify=True` with bucketed raises `NotImplementedError` (per-bucket baseline shape mismatch); dedicated correctness tests cover this path instead.

**Benchmark** (50% ~50-token + 50% ~400-token sequences, padded to 512):
- **3× speedup** (small model), **2× speedup** (larger model)
- **~43% token reduction** vs fixed padding

## Test plan

- [x] 5 unit tests for bucket-building helpers (`_next_power_of_2`, `_detect_left_padding`, `_trim_to_length`, `_build_bucketed_segments`)
- [x] `test_bucketed_padding_basic` — sweep completes, all samples present with finite activations
- [x] `test_bucketed_matches_per_bucket_naive` — per-sample correctness vs HF native forward at real positions
- [x] `test_bucketed_warns_learned_positions` — GPT-2 triggers `UserWarning`
- [x] `test_bucketed_requires_attention_mask` — raises `ValueError` without masks
- [x] All 145 existing tests pass (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)