### PR TITLE
Add cost model preflight: predict throughput and classify bottleneck

### DIFF
--- a/bench/results/70b_streaming_mb_sweep.csv
+++ b/bench/results/70b_streaming_mb_sweep.csv
@@ -1,0 +1,6 @@
+model,n_samples,seq_len,microbatch,n_microbatches,wall_s,tok_s,per_layer_s,per_sample_us,total_load_s,total_fwd_s,total_cb_s,total_write_s,peak_vram_gb,n_layers
+meta-llama/Llama-3.3-70B-Instruct,1024,128,32,32,204.42,641.2,2.5552,199625.0,1.23,102.99,0.005,0.027,6.88,80
+meta-llama/Llama-3.3-70B-Instruct,1024,128,64,16,202.94,645.9,2.5367,198180.4,1.24,101.91,0.003,0.013,7.79,80
+meta-llama/Llama-3.3-70B-Instruct,1024,128,128,8,202.74,646.5,2.5342,197985.3,1.22,101.86,0.002,0.007,9.61,80
+meta-llama/Llama-3.3-70B-Instruct,1024,128,256,4,204.17,642.0,2.5521,199380.9,1.22,103.21,0.001,0.004,13.34,80
+meta-llama/Llama-3.3-70B-Instruct,1024,128,512,2,207.17,632.7,2.5896,202311.6,1.23,105.89,0.001,0.003,21.16,80

--- a/bench/results/8b_streaming_mb_sweep.csv
+++ b/bench/results/8b_streaming_mb_sweep.csv
@@ -1,0 +1,7 @@
+model,n_samples,seq_len,microbatch,n_microbatches,wall_s,tok_s,per_layer_s,per_sample_us,total_load_s,total_fwd_s,total_cb_s,total_write_s,peak_vram_gb,n_layers
+meta-llama/Llama-3.1-8B-Instruct,1024,128,32,32,23.26,5636.3,0.7267,22710.0,0.32,11.83,0.002,0.01,3.03,32
+meta-llama/Llama-3.1-8B-Instruct,1024,128,64,16,22.83,5740.2,0.7136,22298.9,0.32,11.38,0.001,0.005,3.48,32
+meta-llama/Llama-3.1-8B-Instruct,1024,128,128,8,23.02,5694.2,0.7193,22479.0,0.33,11.33,0.001,0.003,4.4,32
+meta-llama/Llama-3.1-8B-Instruct,1024,128,256,4,22.96,5708.2,0.7176,22423.8,0.33,11.3,0.0,0.002,6.22,32
+meta-llama/Llama-3.1-8B-Instruct,1024,128,512,2,23.27,5632.5,0.7272,22725.2,0.32,11.87,0.0,0.001,9.87,32
+meta-llama/Llama-3.1-8B-Instruct,1024,128,1024,1,23.88,5489.7,0.7461,23316.4,0.32,12.05,0.0,0.001,17.61,32

--- a/scripts/study_microbatch.py
+++ b/scripts/study_microbatch.py
@@ -1,0 +1,179 @@
+"""Microbatch size sweep: measure actual throughput at each power-of-2 mb size.
+
+Collects per-layer profile data (load, fwd, write, VRAM) for each microbatch
+candidate. Outputs a CSV for analysis.
+
+Usage:
+    uv run scripts/study_microbatch.py \
+        --model meta-llama/Llama-3.1-8B-Instruct \
+        --n-samples 1024 --seq-len 128
+
+    uv run scripts/study_microbatch.py \
+        --model meta-llama/Llama-3.3-70B-Instruct \
+        --n-samples 1024 --seq-len 128
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import time
+
+import torch
+from transformers import AutoTokenizer
+
+from fpwap import Callback, Sweep
+from fpwap.engine import ProgressEvent
+from fpwap.loader import resolve_snapshot_dir
+from fpwap.types import HookName
+
+
+class NullCapture(Callback):
+    phase = "read"
+    target_layers = "all"
+    target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+    def on_batch(self, layer_idx, hook, acts, sample_ids):
+        return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--n-samples", type=int, default=1024)
+    parser.add_argument("--seq-len", type=int, default=128)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--dtype", default="bfloat16")
+    parser.add_argument("--output", default=None, help="CSV output path")
+    parser.add_argument(
+        "--mb-candidates",
+        default=None,
+        help="comma-separated microbatch sizes to test (default: powers of 2)",
+    )
+    args = parser.parse_args()
+
+    device = torch.device(args.device)
+    dtype = getattr(torch, args.dtype)
+    snapshot = resolve_snapshot_dir(args.model)
+    tokenizer = AutoTokenizer.from_pretrained(snapshot)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
+
+    prompts = [
+        f"The quick brown fox jumps over the lazy dog number {i}."
+        for i in range(args.n_samples)
+    ]
+    batch = tokenizer(
+        prompts,
+        padding="max_length",
+        truncation=True,
+        max_length=args.seq_len,
+        return_tensors="pt",
+    )
+    dataset = [
+        {
+            "input_ids": batch["input_ids"][i : i + 1].to(device),
+            "attention_mask": batch["attention_mask"][i : i + 1].to(device),
+        }
+        for i in range(args.n_samples)
+    ]
+
+    total_tokens = args.n_samples * args.seq_len
+
+    if args.mb_candidates:
+        candidates = [int(x) for x in args.mb_candidates.split(",")]
+    else:
+        candidates = []
+        mb = 1
+        while mb <= args.n_samples:
+            candidates.append(mb)
+            mb *= 2
+
+    log = args.output or f"/tmp/mb_sweep_{args.model.split('/')[-1]}.csv"
+    print(f"model: {args.model}", flush=True)
+    print(f"n_samples={args.n_samples} seq_len={args.seq_len}", flush=True)
+    print(f"candidates: {candidates}", flush=True)
+    print(f"output: {log}", flush=True)
+    print(flush=True)
+
+    rows: list[dict] = []
+
+    for mb in candidates:
+        if mb > args.n_samples:
+            continue
+
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        n_microbatches = -(-args.n_samples // mb)
+
+        def progress(event: ProgressEvent) -> None:
+            pass
+
+        sweep = Sweep(
+            model=str(snapshot),
+            dataset=dataset,
+            seq_len=args.seq_len,
+            callbacks=[NullCapture()],
+            transport_dtype=dtype,
+            seed=0,
+            microbatch_size=mb,
+            buffer_device="cpu",
+            progress=progress,
+            execution_device=str(device),
+        )
+
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        result = sweep.run()
+        torch.cuda.synchronize()
+        wall = time.perf_counter() - t0
+        tps = total_tokens / wall
+
+        total_load = sum(t.load_s for t in result.profile.per_layer.values())
+        total_fwd = sum(t.forward_s for t in result.profile.per_layer.values())
+        total_cb = sum(t.callback_s for t in result.profile.per_layer.values())
+        total_write = sum(t.write_s for t in result.profile.per_layer.values())
+        peak_vram = result.profile.peak_vram_gb()
+        n_layers = len(result.profile.per_layer)
+        per_layer_s = wall / n_layers if n_layers > 0 else 0
+        per_sample_us = wall / args.n_samples * 1e6
+
+        row = {
+            "model": args.model,
+            "n_samples": args.n_samples,
+            "seq_len": args.seq_len,
+            "microbatch": mb,
+            "n_microbatches": n_microbatches,
+            "wall_s": round(wall, 2),
+            "tok_s": round(tps, 1),
+            "per_layer_s": round(per_layer_s, 4),
+            "per_sample_us": round(per_sample_us, 1),
+            "total_load_s": round(total_load, 2),
+            "total_fwd_s": round(total_fwd, 2),
+            "total_cb_s": round(total_cb, 3),
+            "total_write_s": round(total_write, 3),
+            "peak_vram_gb": round(peak_vram, 2),
+            "n_layers": n_layers,
+        }
+        rows.append(row)
+
+        print(
+            f"mb={mb:>5d}  n_mb={n_microbatches:>4d}  "
+            f"wall={wall:>7.2f}s  tok/s={tps:>9,.1f}  "
+            f"per_layer={per_layer_s:.4f}s  "
+            f"VRAM={peak_vram:.1f}GB  "
+            f"load={total_load:.2f}s  fwd={total_fwd:.2f}s",
+            flush=True,
+        )
+
+    if rows:
+        with open(log, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+            writer.writeheader()
+            writer.writerows(rows)
+        print(f"\nwrote {len(rows)} rows to {log}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fpwap/cost_model.py
+++ b/src/fpwap/cost_model.py
@@ -1,0 +1,134 @@
+"""Cost model for predicting fpwap run wall-clock and throughput.
+
+Pure arithmetic — no GPU, no model loading. Fed by measurements from the
+preflight single-layer probe, returns a predicted timing breakdown and
+bottleneck classification.
+
+Cost model per layer:
+    compute_per_layer = fwd_per_microbatch * ceil(n_samples / microbatch_size)
+    load_per_layer    = weight_load_s
+
+    With prefetch:    per_layer = max(load, compute)
+    Without prefetch: per_layer = load + compute
+
+    total = embed_s + per_layer * n_layers
+
+References: FlexGen §4.3 (Sheng et al., ICML 2023), fpwap SPEC §10.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CostModelInput:
+    """Measured quantities from a single-layer preflight probe."""
+
+    n_layers: int
+    n_samples: int
+    seq_len: int
+    microbatch_size: int
+    weight_load_s: float
+    fwd_per_microbatch_s: float
+    embed_s: float
+    layer_weight_bytes: int
+
+
+@dataclass(frozen=True)
+class CostModelPrediction:
+    """Predicted run timing for a specific configuration."""
+
+    per_layer_s: float
+    total_wall_s: float
+    throughput_tok_s: float
+    bottleneck: str
+    load_pct: float
+    compute_pct: float
+    weight_io_gb: float
+    prefetch: bool
+
+
+def predict(inp: CostModelInput, *, prefetch: bool) -> CostModelPrediction:
+    """Predict end-to-end wall-clock from preflight probe measurements."""
+    n_microbatches = -(-inp.n_samples // inp.microbatch_size)
+
+    compute_per_layer = inp.fwd_per_microbatch_s * n_microbatches
+    load_per_layer = inp.weight_load_s
+
+    if prefetch and load_per_layer > 0:
+        per_layer = max(load_per_layer, compute_per_layer)
+    else:
+        per_layer = load_per_layer + compute_per_layer
+
+    total = inp.embed_s + per_layer * inp.n_layers
+    total_tokens = inp.n_samples * inp.seq_len
+    throughput = total_tokens / total if total > 0.0 else 0.0
+
+    non_overlap = load_per_layer + compute_per_layer
+    if non_overlap > 0:
+        load_pct = load_per_layer / non_overlap
+        compute_pct = compute_per_layer / non_overlap
+    else:
+        load_pct = 0.0
+        compute_pct = 0.0
+
+    if load_pct > 0.55:
+        bottleneck = "load"
+    elif compute_pct > 0.55:
+        bottleneck = "compute"
+    else:
+        bottleneck = "balanced"
+
+    weight_io_gb = inp.layer_weight_bytes * inp.n_layers / 1e9
+
+    return CostModelPrediction(
+        per_layer_s=per_layer,
+        total_wall_s=total,
+        throughput_tok_s=throughput,
+        bottleneck=bottleneck,
+        load_pct=load_pct,
+        compute_pct=compute_pct,
+        weight_io_gb=weight_io_gb,
+        prefetch=prefetch,
+    )
+
+
+@dataclass(frozen=True)
+class CandidateConfig:
+    """One configuration to evaluate in the parameter search."""
+
+    cost_input: CostModelInput
+    buffer_device: str
+    prefetch: bool
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    """Best configuration found by the cost model search."""
+
+    microbatch_size: int
+    buffer_device: str
+    prefetch: bool
+    prediction: CostModelPrediction
+
+
+def recommend(candidates: Sequence[CandidateConfig]) -> Recommendation:
+    """Evaluate candidate configs and return the highest-throughput one."""
+    if not candidates:
+        raise ValueError("no candidate configurations to evaluate")
+
+    best: Recommendation | None = None
+    for c in candidates:
+        pred = predict(c.cost_input, prefetch=c.prefetch)
+        if best is None or pred.throughput_tok_s > best.prediction.throughput_tok_s:
+            best = Recommendation(
+                microbatch_size=c.cost_input.microbatch_size,
+                buffer_device=c.buffer_device,
+                prefetch=c.prefetch,
+                prediction=pred,
+            )
+
+    assert best is not None
+    return best

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -61,6 +61,7 @@ class LayerTiming:
     write_s: float = 0.0
     bytes_weights: int = 0
     bytes_buffer: int = 0
+    peak_vram_bytes: int = 0
 
 
 @dataclass
@@ -134,10 +135,14 @@ class ProfileReport:
             lines.append(f"  loop  {self.loop_s:.3f}s")
         if self.teardown_s > 0:
             lines.append(f"  teardown {self.teardown_s:.3f}s")
+        peak = self.peak_vram_gb()
+        if peak > 0:
+            lines.append(f"  peak VRAM {peak:.1f} GB")
         for i, t in sorted(self.per_layer.items()):
+            vram_str = f"  vram {t.peak_vram_bytes / 1e9:.1f}GB" if t.peak_vram_bytes > 0 else ""
             lines.append(
                 f"  layer {i}: load {t.load_s:.3f}s  fwd {t.forward_s:.3f}s  "
-                f"cb {t.callback_s:.3f}s  write {t.write_s:.3f}s"
+                f"cb {t.callback_s:.3f}s  write {t.write_s:.3f}s{vram_str}"
             )
         return "\n".join(lines)
 
@@ -170,6 +175,12 @@ class ProfileReport:
                     worst_i = i
                     worst_phase = name.removesuffix("_s")
         return (worst_i, worst_phase)
+
+    def peak_vram_gb(self) -> float:
+        """Peak VRAM allocated across all layers, in GB."""
+        if not self.per_layer:
+            return 0.0
+        return max(t.peak_vram_bytes for t in self.per_layer.values()) / 1e9
 
     def bytes_moved(self) -> dict[str, int]:
         w = sum(t.bytes_weights for t in self.per_layer.values())
@@ -731,6 +742,9 @@ class Sweep:
             torch.cuda.synchronize()
         embed_s = (time.perf_counter_ns() - t_embed_0) / 1e9
 
+        if exec_device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats()
+
         t_fwd_0 = time.perf_counter_ns()
         with torch.no_grad():
             _ = plumbing.layer_forward_with_hooks(
@@ -739,6 +753,10 @@ class Sweep:
         if exec_device.type == "cuda":
             torch.cuda.synchronize()
         fwd_per_microbatch_s = (time.perf_counter_ns() - t_fwd_0) / 1e9
+
+        probe_peak_vram_gb = 0.0
+        if exec_device.type == "cuda":
+            probe_peak_vram_gb = torch.cuda.max_memory_allocated() / 1e9
 
         streamer.unload_layer(model, 0, plumbing)
         del input_ids, hidden_states
@@ -782,7 +800,7 @@ class Sweep:
             feasible=True,
             microbatch_size=mb_size,
             residual_buffer_gb=residual_gb,
-            per_layer_peak_vram_gb=0.0,
+            per_layer_peak_vram_gb=probe_peak_vram_gb,
             estimated_wall_clock_s=rec.prediction.total_wall_s,
             estimated_weight_io_gb=est_weight_io_gb,
             loading_strategy="cpu_offload",
@@ -1240,7 +1258,16 @@ class Sweep:
             # wins from letting writes overlap with compute within the layer.
             if exec_device.type == "cuda":
                 torch.cuda.synchronize()
+                timing.peak_vram_bytes = torch.cuda.max_memory_allocated()
             _emit_progress("layer_end", layer_idx, n_batches, n_batches)
+
+            if hasattr(layer_iter, "set_postfix"):
+                elapsed = (time.perf_counter_ns() - t0_run) / 1e9
+                tps = profile.total_tokens / elapsed if elapsed > 0 else 0
+                postfix = {"tok/s": f"{tps:,.0f}"}
+                if timing.peak_vram_bytes > 0:
+                    postfix["VRAM"] = f"{timing.peak_vram_bytes / 1e9:.1f}GB"
+                layer_iter.set_postfix(postfix)
 
             for cb in self.callbacks:
                 layer_art = cb.on_layer_end(layer_idx)

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -645,13 +645,18 @@ class Sweep:
         )
 
     def preflight(self) -> PreflightReport:
-        """Minimum-viable feasibility + wall-clock estimate.
+        """Feasibility gate + cost-model throughput prediction.
 
-        Runs the embed pass + a single-layer dry-run on a small slice of the
-        dataset, measures wall-clock, and extrapolates. Not the full SPEC §10
-        planner (no microbatch binary search, no VRAM static analysis); this
-        is the "does this configuration even start" gate plus a rough ETA.
+        Probes a single layer: times weight load, embedding, and forward
+        separately, feeds those into the cost model, and returns a predicted
+        wall-clock, throughput, bottleneck classification, and recommended
+        configuration (buffer_device, prefetch).
         """
+        from fpwap.cost_model import (
+            CandidateConfig,
+            CostModelInput,
+            recommend,
+        )
         from fpwap.preflight import PreflightReport as _Report
 
         items = _resolve_dataset(self.dataset)
@@ -705,38 +710,85 @@ class Sweep:
         )
         residual_gb = n_samples * self.seq_len * hidden * element_bytes / 1e9
 
-        streamer.ensure_embedding_loaded(model, plumbing)
-        streamer.load_layer(model, 0, plumbing)
+        is_streaming = isinstance(streamer, _OffloadStreamer)
 
-        probe_ids = torch.arange(mb_size, device=buf_device)
+        # --- Probe: time weight load, embed, and forward separately ---
+        streamer.ensure_embedding_loaded(model, plumbing)
+
+        t_load_0 = time.perf_counter_ns()
+        streamer.load_layer(model, 0, plumbing)
+        if exec_device.type == "cuda":
+            torch.cuda.synchronize()
+        weight_load_s = (time.perf_counter_ns() - t_load_0) / 1e9
+        layer_weight_bytes = streamer.last_load_bytes
+
         input_ids = _stack_field(items[:mb_size], "input_ids").to(exec_device)
-        t0 = time.perf_counter_ns()
+
+        t_embed_0 = time.perf_counter_ns()
         with torch.no_grad():
             hidden_states = plumbing.embed(model, input_ids)
+        if exec_device.type == "cuda":
+            torch.cuda.synchronize()
+        embed_s = (time.perf_counter_ns() - t_embed_0) / 1e9
+
+        t_fwd_0 = time.perf_counter_ns()
+        with torch.no_grad():
             _ = plumbing.layer_forward_with_hooks(
                 model, plumbing.layer_modules(model)[0], hidden_states
             )
         if exec_device.type == "cuda":
             torch.cuda.synchronize()
-        probe_s = (time.perf_counter_ns() - t0) / 1e9
-        streamer.unload_layer(model, 0, plumbing)
-        del probe_ids, input_ids, hidden_states
+        fwd_per_microbatch_s = (time.perf_counter_ns() - t_fwd_0) / 1e9
 
-        n_microbatches = (n_samples + mb_size - 1) // mb_size
-        est_wall = probe_s * n_layers * n_microbatches
-        est_weight_io_gb = streamer.last_load_bytes * n_layers / 1e9
+        streamer.unload_layer(model, 0, plumbing)
+        del input_ids, hidden_states
+
+        # --- Cost model: evaluate candidate configurations ---
+        base_input = CostModelInput(
+            n_layers=n_layers,
+            n_samples=n_samples,
+            seq_len=self.seq_len,
+            microbatch_size=mb_size,
+            weight_load_s=weight_load_s,
+            fwd_per_microbatch_s=fwd_per_microbatch_s,
+            embed_s=embed_s,
+            layer_weight_bytes=layer_weight_bytes,
+        )
+
+        candidates: list[CandidateConfig] = []
+        if isinstance(buf_device, torch.device):
+            buf_device_str = "cpu" if buf_device.type == "cpu" else "cuda"
+        elif isinstance(buf_device, str):
+            buf_device_str = "cpu" if buf_device == "cpu" else "cuda"
+        else:
+            buf_device_str = "cuda"
+
+        if is_streaming:
+            candidates.append(CandidateConfig(
+                cost_input=base_input, buffer_device=buf_device_str, prefetch=True,
+            ))
+            candidates.append(CandidateConfig(
+                cost_input=base_input, buffer_device=buf_device_str, prefetch=False,
+            ))
+        else:
+            candidates.append(CandidateConfig(
+                cost_input=base_input, buffer_device=buf_device_str, prefetch=False,
+            ))
+
+        rec = recommend(candidates)
+        est_weight_io_gb = layer_weight_bytes * n_layers / 1e9
 
         return _Report(
             feasible=True,
             microbatch_size=mb_size,
             residual_buffer_gb=residual_gb,
-            per_layer_peak_vram_gb=0.0,  # static analysis deferred
-            estimated_wall_clock_s=est_wall,
+            per_layer_peak_vram_gb=0.0,
+            estimated_wall_clock_s=rec.prediction.total_wall_s,
             estimated_weight_io_gb=est_weight_io_gb,
             loading_strategy="cpu_offload",
-            warnings=(
-                ["preflight is a minimal wall-clock estimate, not a full planner"]
-            ),
+            prediction=rec.prediction,
+            recommended_buffer_device=rec.buffer_device,
+            recommended_prefetch=rec.prefetch if is_streaming else None,
         )
 
     def _resolve_model_and_streamer(

--- a/src/fpwap/preflight.py
+++ b/src/fpwap/preflight.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 
 from fpwap.callbacks.base import Callback
+from fpwap.cost_model import CostModelPrediction
 from fpwap.types import LoadingStrategy
 
 
@@ -21,6 +22,56 @@ class PreflightReport:
     loading_strategy: LoadingStrategy
     blockers: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    prediction: CostModelPrediction | None = None
+    recommended_buffer_device: str | None = None
+    recommended_prefetch: bool | None = None
+
+    def summary(self) -> str:
+        """Human-readable preflight summary with cost model predictions."""
+        lines: list[str] = []
+        status = "feasible" if self.feasible else "INFEASIBLE"
+        lines.append(f"{status} | microbatch_size={self.microbatch_size}")
+
+        if self.blockers:
+            for b in self.blockers:
+                lines.append(f"  BLOCKER: {b}")
+
+        if self.prediction is not None:
+            p = self.prediction
+            mins = p.total_wall_s / 60
+            if mins >= 1.0:
+                lines.append(
+                    f"predicted: {mins:.1f} min wall-clock, "
+                    f"{p.throughput_tok_s:,.0f} tok/s"
+                )
+            else:
+                lines.append(
+                    f"predicted: {p.total_wall_s:.1f}s wall-clock, "
+                    f"{p.throughput_tok_s:,.0f} tok/s"
+                )
+            lines.append(
+                f"bottleneck: {p.bottleneck} "
+                f"(load {p.load_pct:.0%}, compute {p.compute_pct:.0%})"
+            )
+            lines.append(f"weight I/O: {p.weight_io_gb:.1f} GB")
+        else:
+            lines.append(
+                f"estimated wall-clock: {self.estimated_wall_clock_s:.1f}s"
+            )
+            lines.append(f"weight I/O: {self.estimated_weight_io_gb:.1f} GB")
+
+        recs: list[str] = []
+        if self.recommended_buffer_device is not None:
+            recs.append(f"buffer_device={self.recommended_buffer_device!r}")
+        if self.recommended_prefetch is not None:
+            recs.append(f"prefetch={'on' if self.recommended_prefetch else 'off'}")
+        if recs:
+            lines.append(f"recommended: {', '.join(recs)}")
+
+        for w in self.warnings:
+            lines.append(f"  warning: {w}")
+
+        return "\n".join(lines)
 
 
 def _select_loading_strategy(

--- a/src/fpwap/preflight.py
+++ b/src/fpwap/preflight.py
@@ -60,6 +60,9 @@ class PreflightReport:
             )
             lines.append(f"weight I/O: {self.estimated_weight_io_gb:.1f} GB")
 
+        if self.per_layer_peak_vram_gb > 0:
+            lines.append(f"peak VRAM: {self.per_layer_peak_vram_gb:.1f} GB")
+
         recs: list[str] = []
         if self.recommended_buffer_device is not None:
             recs.append(f"buffer_device={self.recommended_buffer_device!r}")

--- a/tests/integration/test_preflight_minimum.py
+++ b/tests/integration/test_preflight_minimum.py
@@ -58,6 +58,13 @@ def test_preflight_reports_feasible() -> None:
     assert report.estimated_wall_clock_s > 0
     assert not report.blockers
 
+    assert report.prediction is not None
+    assert report.prediction.throughput_tok_s > 0
+    assert report.prediction.bottleneck in ("load", "compute", "balanced")
+    summary = report.summary()
+    assert "feasible" in summary
+    assert "tok/s" in summary
+
 
 @pytest.mark.integration
 def test_preflight_blocks_empty_dataset() -> None:

--- a/tests/unit/test_cost_model.py
+++ b/tests/unit/test_cost_model.py
@@ -1,0 +1,256 @@
+"""Unit tests for cost_model — CI-safe, no GPU required."""
+
+from __future__ import annotations
+
+import pytest
+
+from fpwap.cost_model import (
+    CandidateConfig,
+    CostModelInput,
+    CostModelPrediction,
+    predict,
+    recommend,
+)
+from fpwap.preflight import PreflightReport
+
+
+def _make_input(
+    *,
+    n_layers: int = 80,
+    n_samples: int = 10_000,
+    seq_len: int = 128,
+    microbatch_size: int = 64,
+    weight_load_s: float = 0.5,
+    fwd_per_microbatch_s: float = 0.01,
+    embed_s: float = 0.5,
+    layer_weight_bytes: int = 1_750_000_000,
+) -> CostModelInput:
+    return CostModelInput(
+        n_layers=n_layers,
+        n_samples=n_samples,
+        seq_len=seq_len,
+        microbatch_size=microbatch_size,
+        weight_load_s=weight_load_s,
+        fwd_per_microbatch_s=fwd_per_microbatch_s,
+        embed_s=embed_s,
+        layer_weight_bytes=layer_weight_bytes,
+    )
+
+
+class TestPredict:
+    def test_compute_bound(self) -> None:
+        inp = _make_input(weight_load_s=0.1, fwd_per_microbatch_s=0.05)
+        pred = predict(inp, prefetch=True)
+        assert pred.bottleneck == "compute"
+        assert pred.compute_pct > pred.load_pct
+
+    def test_load_bound(self) -> None:
+        inp = _make_input(weight_load_s=2.0, fwd_per_microbatch_s=0.001)
+        pred = predict(inp, prefetch=True)
+        assert pred.bottleneck == "load"
+        assert pred.load_pct > pred.compute_pct
+
+    def test_balanced(self) -> None:
+        inp = _make_input(weight_load_s=1.0, fwd_per_microbatch_s=0.00625)
+        n_mb = -(-10_000 // 64)
+        compute = 0.00625 * n_mb
+        assert abs(compute - 1.0) < 0.05
+        pred = predict(inp, prefetch=True)
+        assert pred.bottleneck == "balanced"
+
+    def test_prefetch_overlaps_load(self) -> None:
+        inp = _make_input(weight_load_s=1.0, fwd_per_microbatch_s=0.05)
+        with_pf = predict(inp, prefetch=True)
+        without_pf = predict(inp, prefetch=False)
+        n_mb = -(-10_000 // 64)
+        compute = 0.05 * n_mb
+
+        assert with_pf.per_layer_s == pytest.approx(max(1.0, compute))
+        assert without_pf.per_layer_s == pytest.approx(1.0 + compute)
+        assert with_pf.total_wall_s < without_pf.total_wall_s
+
+    def test_no_prefetch_sequential(self) -> None:
+        inp = _make_input(weight_load_s=0.5, fwd_per_microbatch_s=0.01)
+        pred = predict(inp, prefetch=False)
+        n_mb = -(-10_000 // 64)
+        expected_per_layer = 0.5 + 0.01 * n_mb
+        assert pred.per_layer_s == pytest.approx(expected_per_layer)
+
+    def test_throughput_calculation(self) -> None:
+        inp = _make_input(n_samples=1000, seq_len=128, embed_s=0.0)
+        pred = predict(inp, prefetch=False)
+        expected_tokens = 1000 * 128
+        assert pred.throughput_tok_s == pytest.approx(
+            expected_tokens / pred.total_wall_s
+        )
+
+    def test_zero_load_preloaded(self) -> None:
+        inp = _make_input(weight_load_s=0.0, fwd_per_microbatch_s=0.01)
+        pred = predict(inp, prefetch=True)
+        n_mb = -(-10_000 // 64)
+        assert pred.per_layer_s == pytest.approx(0.01 * n_mb)
+        assert pred.load_pct == 0.0
+        assert pred.bottleneck == "compute"
+
+    def test_weight_io_gb(self) -> None:
+        inp = _make_input(n_layers=80, layer_weight_bytes=1_750_000_000)
+        pred = predict(inp, prefetch=True)
+        assert pred.weight_io_gb == pytest.approx(80 * 1.75)
+
+    def test_ceil_div_microbatches(self) -> None:
+        inp = _make_input(n_samples=100, microbatch_size=64, fwd_per_microbatch_s=1.0)
+        pred = predict(inp, prefetch=False)
+        assert pred.per_layer_s == pytest.approx(inp.weight_load_s + 2.0)
+
+    def test_exact_div_microbatches(self) -> None:
+        inp = _make_input(n_samples=128, microbatch_size=64, fwd_per_microbatch_s=1.0)
+        pred = predict(inp, prefetch=False)
+        assert pred.per_layer_s == pytest.approx(inp.weight_load_s + 2.0)
+
+    def test_zero_total_returns_zero_throughput(self) -> None:
+        inp = _make_input(
+            weight_load_s=0.0, fwd_per_microbatch_s=0.0, embed_s=0.0
+        )
+        pred = predict(inp, prefetch=True)
+        assert pred.throughput_tok_s == 0.0
+
+    def test_prediction_has_prefetch_flag(self) -> None:
+        inp = _make_input()
+        assert predict(inp, prefetch=True).prefetch is True
+        assert predict(inp, prefetch=False).prefetch is False
+
+    def test_load_pct_plus_compute_pct_sums_to_one(self) -> None:
+        inp = _make_input(weight_load_s=0.3, fwd_per_microbatch_s=0.02)
+        pred = predict(inp, prefetch=True)
+        assert pred.load_pct + pred.compute_pct == pytest.approx(1.0)
+
+
+class TestRecommend:
+    def test_picks_highest_throughput(self) -> None:
+        fast = _make_input(weight_load_s=0.1, fwd_per_microbatch_s=0.005)
+        slow = _make_input(weight_load_s=2.0, fwd_per_microbatch_s=0.05)
+        rec = recommend([
+            CandidateConfig(cost_input=fast, buffer_device="cpu", prefetch=True),
+            CandidateConfig(cost_input=slow, buffer_device="cuda", prefetch=True),
+        ])
+        assert rec.buffer_device == "cpu"
+        assert rec.prediction.throughput_tok_s > 0
+
+    def test_prefetch_beats_no_prefetch(self) -> None:
+        inp = _make_input(weight_load_s=1.0, fwd_per_microbatch_s=0.01)
+        rec = recommend([
+            CandidateConfig(cost_input=inp, buffer_device="cuda", prefetch=True),
+            CandidateConfig(cost_input=inp, buffer_device="cuda", prefetch=False),
+        ])
+        assert rec.prefetch is True
+
+    def test_empty_candidates_raises(self) -> None:
+        with pytest.raises(ValueError, match="no candidate"):
+            recommend([])
+
+    def test_single_candidate(self) -> None:
+        inp = _make_input()
+        rec = recommend([
+            CandidateConfig(cost_input=inp, buffer_device="cuda", prefetch=True),
+        ])
+        assert rec.microbatch_size == inp.microbatch_size
+        assert rec.prediction.total_wall_s > 0
+
+    def test_larger_microbatch_preferred_when_faster(self) -> None:
+        small_mb = _make_input(microbatch_size=8, fwd_per_microbatch_s=0.002)
+        large_mb = _make_input(microbatch_size=64, fwd_per_microbatch_s=0.01)
+        rec = recommend([
+            CandidateConfig(cost_input=small_mb, buffer_device="cuda", prefetch=True),
+            CandidateConfig(cost_input=large_mb, buffer_device="cuda", prefetch=True),
+        ])
+        assert rec.microbatch_size == 64
+
+
+class TestPreflightSummary:
+    def test_summary_with_prediction(self) -> None:
+        pred = CostModelPrediction(
+            per_layer_s=1.0,
+            total_wall_s=120.0,
+            throughput_tok_s=1000.0,
+            bottleneck="compute",
+            load_pct=0.3,
+            compute_pct=0.7,
+            weight_io_gb=140.0,
+            prefetch=True,
+        )
+        report = PreflightReport(
+            feasible=True,
+            microbatch_size=64,
+            residual_buffer_gb=20.0,
+            per_layer_peak_vram_gb=0.0,
+            estimated_wall_clock_s=120.0,
+            estimated_weight_io_gb=140.0,
+            loading_strategy="disk_offload",
+            prediction=pred,
+            recommended_buffer_device="cpu",
+            recommended_prefetch=True,
+        )
+        s = report.summary()
+        assert "feasible" in s
+        assert "microbatch_size=64" in s
+        assert "2.0 min" in s
+        assert "1,000 tok/s" in s
+        assert "compute" in s
+        assert "140.0 GB" in s
+        assert "buffer_device='cpu'" in s
+        assert "prefetch=on" in s
+
+    def test_summary_without_prediction(self) -> None:
+        report = PreflightReport(
+            feasible=True,
+            microbatch_size=32,
+            residual_buffer_gb=10.0,
+            per_layer_peak_vram_gb=0.0,
+            estimated_wall_clock_s=60.0,
+            estimated_weight_io_gb=16.0,
+            loading_strategy="cpu_offload",
+        )
+        s = report.summary()
+        assert "feasible" in s
+        assert "60.0s" in s
+        assert "16.0 GB" in s
+
+    def test_summary_infeasible(self) -> None:
+        report = PreflightReport(
+            feasible=False,
+            microbatch_size=0,
+            residual_buffer_gb=0.0,
+            per_layer_peak_vram_gb=0.0,
+            estimated_wall_clock_s=0.0,
+            estimated_weight_io_gb=0.0,
+            loading_strategy="cpu_offload",
+            blockers=["dataset is empty"],
+        )
+        s = report.summary()
+        assert "INFEASIBLE" in s
+        assert "dataset is empty" in s
+
+    def test_summary_sub_minute(self) -> None:
+        pred = CostModelPrediction(
+            per_layer_s=0.1,
+            total_wall_s=30.0,
+            throughput_tok_s=5000.0,
+            bottleneck="compute",
+            load_pct=0.1,
+            compute_pct=0.9,
+            weight_io_gb=16.0,
+            prefetch=True,
+        )
+        report = PreflightReport(
+            feasible=True,
+            microbatch_size=128,
+            residual_buffer_gb=5.0,
+            per_layer_peak_vram_gb=0.0,
+            estimated_wall_clock_s=30.0,
+            estimated_weight_io_gb=16.0,
+            loading_strategy="cpu_offload",
+            prediction=pred,
+        )
+        s = report.summary()
+        assert "30.0s" in s
+        assert "min" not in s

--- a/tests/unit/test_profile_metrics.py
+++ b/tests/unit/test_profile_metrics.py
@@ -35,3 +35,28 @@ def test_summary_includes_throughput_line() -> None:
     assert "throughput" in s
     assert "1,000.0 tok/s" in s
     assert "tokens 2000" in s
+
+
+def test_peak_vram_gb() -> None:
+    r = ProfileReport(
+        per_layer={
+            0: LayerTiming(peak_vram_bytes=10_000_000_000),
+            1: LayerTiming(peak_vram_bytes=12_000_000_000),
+            2: LayerTiming(peak_vram_bytes=11_000_000_000),
+        },
+    )
+    assert r.peak_vram_gb() == 12.0
+
+
+def test_peak_vram_in_summary() -> None:
+    r = ProfileReport(
+        total_wall_s=1.0,
+        total_tokens=1_000,
+        per_layer={
+            0: LayerTiming(
+                load_s=0.1, forward_s=0.5, peak_vram_bytes=8_500_000_000
+            ),
+        },
+    )
+    s = r.summary()
+    assert "peak VRAM 8.5 GB" in s


### PR DESCRIPTION
## Summary

Closes #31.

- **New `cost_model.py` module** — pure-arithmetic cost model: `T_layer = max(load, compute)` with prefetch overlap, `load + compute` without. Predicts wall-clock, throughput (tok/s), bottleneck classification (load/compute/balanced), and weight I/O. `recommend()` evaluates candidate configs and picks the highest-throughput one.
- **`PreflightReport.summary()`** — human-readable output with predicted throughput, bottleneck breakdown, and recommended configuration. e.g. `"feasible | microbatch_size=64\npredicted: 42.3 min wall-clock, 1,005 tok/s\nbottleneck: compute (load 38%, compute 62%)"`.
- **Enhanced preflight probe** — `Sweep.preflight()` now times weight load, embedding, and forward separately (instead of one combined measurement), builds a `CostModelInput`, evaluates prefetch on/off, and attaches the prediction + recommendation to the report.
- **22 new unit tests** for cost model math (predict, recommend, summary), all CI-safe (no GPU). Integration test updated to assert prediction fields.

### Cost model

```
compute_per_layer = fwd_per_microbatch × ceil(n_samples / microbatch_size)
load_per_layer    = weight_load_s

With prefetch:    per_layer = max(load, compute)
Without prefetch: per_layer = load + compute

total = embed_s + per_layer × n_layers
```

References: FlexGen §4.3, fpwap SPEC §10.

## Test plan

- [x] 22 unit tests: bottleneck classification, prefetch overlap math, throughput calculation, ceil-div edge cases, recommendation search, summary formatting
- [x] Integration test: `test_preflight_reports_feasible` now asserts prediction is non-None, throughput > 0, bottleneck valid, and summary contains expected strings
- [x] Full `ruff check` clean
- [x] All 167 non-GPU tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)