### PR TITLE
Add padding= kwarg to Extractor.sweep()

### DIFF
--- a/src/fpwap/extractor.py
+++ b/src/fpwap/extractor.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from fpwap.callbacks.base import Callback
 from fpwap.storage import StorageBackend
-from fpwap.types import LoadingStrategy
+from fpwap.types import LoadingStrategy, PaddingMode
 
 if TYPE_CHECKING:
     from fpwap.engine import Sweep
@@ -83,6 +83,7 @@ class Extractor:
         buffer_device: torch.device | str | None = None,
         apply_final_norm: bool = True,
         chunk_size: int = 1,
+        padding: PaddingMode = "fixed",
     ) -> Sweep:
         """Create a Sweep that reuses this Extractor's model and index."""
         from fpwap.engine import Sweep
@@ -105,5 +106,6 @@ class Extractor:
             buffer_device=buffer_device,
             apply_final_norm=apply_final_norm,
             chunk_size=chunk_size,
+            padding=padding,
             _accel_index=self._accel_index,
         )

--- a/tests/integration/test_extractor.py
+++ b/tests/integration/test_extractor.py
@@ -175,6 +175,35 @@ def test_extractor_sweep_uses_streaming_path(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
+def test_extractor_sweep_forwards_padding(tmp_path: Path) -> None:
+    """Extractor.sweep(padding='bucketed') forwards the kwarg to Sweep."""
+    from fpwap import Extractor
+    from fpwap.callbacks.common import RawActivations
+
+    snapshot_dir = tmp_path / "snapshot"
+    _write_tiny_gpt2_snapshot(snapshot_dir)
+
+    ext = Extractor.from_hf(str(snapshot_dir), dtype=torch.float32)
+
+    torch.manual_seed(SEED + 1)
+    input_ids = torch.randint(0, VOCAB, (N_SAMPLES, SEQ_LEN))
+
+    raw = RawActivations(layers="all", last_token_only=False, out_dtype=torch.float32)
+    sweep = ext.sweep(
+        dataset=[{"input_ids": input_ids[i : i + 1]} for i in range(N_SAMPLES)],
+        seq_len=SEQ_LEN,
+        callbacks=[raw],
+        transport_dtype=torch.float32,
+        execution_device="cpu",
+        seed=SEED,
+        apply_final_norm=False,
+        progress=False,
+        padding="bucketed",
+    )
+    assert sweep.padding == "bucketed"
+
+
+@pytest.mark.integration
 def test_extractor_requires_execution_device(tmp_path: Path) -> None:
     """Extractor.sweep() without execution_device must raise."""
     from fpwap import Extractor


### PR DESCRIPTION
## Summary
- Adds `padding: PaddingMode = "fixed"` parameter to `Extractor.sweep()` and forwards it to `Sweep(...)`.
- Consumers can now pass `padding="bucketed"` directly instead of mutating `sweep.padding` after construction.

Fixes #39

## Test plan
- [x] New `test_extractor_sweep_forwards_padding` asserts `ext.sweep(..., padding="bucketed").padding == "bucketed"`
- [x] All 4 extractor integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)