### PR TITLE
Fix result.activations() for bucketed padding

### DIFF
--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -183,6 +183,8 @@ class Result:
     artifacts: dict[tuple[str, int], Artifact] = field(default_factory=dict)
     storage: StorageBackend | None = None
     profile: ProfileReport = field(default_factory=ProfileReport)
+    seq_len: int | None = None
+    _left_padded: bool = True
     # When no StorageBackend is set, Emit outputs are collected in memory per
     # (layer, hook). Fine for moderate-size sweeps; for dataset-scale
     # extraction, swap in a storage backend to avoid RAM pressure.
@@ -212,6 +214,19 @@ class Result:
         parts = self._emits[key]
         ordered = sorted(parts, key=lambda p: int(p[0][0]))
         tensors = [t for _, t in ordered]
+        if tensors and tensors[0].dim() >= 2:
+            seq_dims = {t.shape[1] for t in tensors}
+            if len(seq_dims) > 1:
+                target = self.seq_len if self.seq_len is not None else max(seq_dims)
+                padded = []
+                for t in tensors:
+                    gap = target - t.shape[1]
+                    if gap > 0:
+                        pad_shape = (t.shape[0], gap, *t.shape[2:])
+                        z = torch.zeros(pad_shape, dtype=t.dtype, device=t.device)
+                        t = torch.cat([z, t] if self._left_padded else [t, z], dim=1)
+                    padded.append(t)
+                tensors = padded
         return torch.cat(tensors, dim=0)
 
 
@@ -979,12 +994,14 @@ class Sweep:
                     UserWarning,
                     stacklevel=2,
                 )
+            left_padded = _detect_left_padding(items)
             mb_override: int | None = None if self.microbatch_size == "auto" else mb_size
             segments = _build_bucketed_segments(
                 items, self.seq_len, hidden, self.transport_dtype,
                 buf_device, mb_override, config, exec_device,
             )
         else:
+            left_padded = True
             buffer = ResidualBuffer(
                 n_samples=n_samples,
                 seq_len=self.seq_len,
@@ -1349,6 +1366,8 @@ class Sweep:
             artifacts=artifacts,
             storage=self.storage,
             profile=profile,
+            seq_len=self.seq_len,
+            _left_padded=left_padded,
             _emits=emits_sink,
         )
 

--- a/tests/integration/test_bucketed_padding.py
+++ b/tests/integration/test_bucketed_padding.py
@@ -206,6 +206,36 @@ def test_bucketed_matches_per_bucket_naive() -> None:
 
 
 @pytest.mark.integration
+def test_bucketed_result_activations_reassembles() -> None:
+    """result.activations() produces [N, seq_len, H] from bucketed emits."""
+    from fpwap import Sweep
+    from fpwap.callbacks.common import RawActivations
+
+    model = _tiny_gpt2()
+    items = _mixed_length_dataset()
+
+    raw = RawActivations(layers="all", last_token_only=False, out_dtype=torch.float32)
+    sweep = Sweep(
+        model=model,
+        dataset=items,
+        seq_len=SEQ_LEN,
+        callbacks=[raw],
+        transport_dtype=torch.float32,
+        padding="bucketed",
+        apply_final_norm=False,
+    )
+    result = sweep.run()
+
+    for layer_idx in range(N_LAYERS):
+        acts = result.activations(layer_idx, "residual_post")
+        assert acts.shape == (N_SAMPLES, SEQ_LEN, HIDDEN), (
+            f"layer {layer_idx}: expected ({N_SAMPLES}, {SEQ_LEN}, {HIDDEN}), "
+            f"got {tuple(acts.shape)}"
+        )
+        assert torch.isfinite(acts).all()
+
+
+@pytest.mark.integration
 
 def test_bucketed_warns_learned_positions() -> None:
     """padding='bucketed' emits a UserWarning for GPT-2 (learned positional embeddings)."""


### PR DESCRIPTION
## Summary
- `result.activations(layer, hook)` now works with `padding="bucketed"` sweeps. Previously it raised `RuntimeError` on `torch.cat` because different buckets emitted tensors with mismatched `seq_len` dimensions.
- `Result` now carries `seq_len` and `_left_padded` from the sweep. When bucket emits have mismatched sequence lengths, shorter tensors are zero-padded back to the global `seq_len` before concatenation, producing the expected `[N, seq_len, H]` output.
- Last-token-only users (`[mb, H]` shape) were never affected — this fix is specific to full-sequence extraction.

Fixes #40

## Test plan
- [x] New `test_bucketed_result_activations_reassembles` verifies `result.activations()` returns `(N_SAMPLES, SEQ_LEN, HIDDEN)` from a bucketed sweep with mixed-length inputs
- [x] All 65 integration tests pass, no regressions
- [x] All 115 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)