### PR TITLE
posix_fadvise(DONTNEED) on MemmapBackend emit shards after write

### DIFF
--- a/src/fpwap/storage/memmap.py
+++ b/src/fpwap/storage/memmap.py
@@ -13,6 +13,7 @@ on the SPEC §17 target workload (Llama-70B × 10k prompts × 128 tokens ≈
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,8 @@ import torch
 from torch import Tensor
 
 from fpwap.types import HookName
+
+_HAS_POSIX_FADVISE = hasattr(os, "posix_fadvise")
 
 _TORCH_TO_NUMPY: dict[torch.dtype, Any] = {
     torch.float32: np.float32,
@@ -86,6 +89,27 @@ class _Shard:
         if self._stores_bf16_as_u16:
             host = host.view(torch.uint16)
         mm[ids_np] = host.numpy()
+        self._flush_and_evict()
+
+    def _flush_and_evict(self) -> None:
+        """Flush dirty pages to disk, then advise the kernel to reclaim them.
+
+        Emit shards are write-once-read-at-end; without this, written pages
+        stay hot in page cache for the entire sweep, stealing budget from
+        weight and residual streaming (see #50).
+        """
+        if self._mm is None:
+            return
+        self._mm.flush()
+        if _HAS_POSIX_FADVISE:
+            try:
+                fd = os.open(str(self.path), os.O_RDONLY)
+                try:
+                    os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+                finally:
+                    os.close(fd)
+            except OSError:
+                pass
 
     def read(self) -> Tensor:
         if self._mm is None:

--- a/tests/unit/test_memmap_shard_fadvise.py
+++ b/tests/unit/test_memmap_shard_fadvise.py
@@ -1,0 +1,80 @@
+"""Unit tests for posix_fadvise(DONTNEED) on MemmapBackend emit shards (#50)."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+from fpwap.storage.memmap import MemmapBackend, _Shard
+
+
+class TestShardFlushAndEvict:
+    def test_fadvise_called_after_write(self, tmp_path: Path) -> None:
+        shard = _Shard(tmp_path / "test.bin", n_samples=4)
+        t = torch.randn(2, 8, dtype=torch.float32)
+        ids = torch.tensor([0, 2])
+
+        with patch("fpwap.storage.memmap.os.posix_fadvise") as mock_fadvise:
+            shard.write(ids, t)
+            assert mock_fadvise.call_count == 1
+            fd, offset, length, advice = mock_fadvise.call_args.args
+            assert offset == 0
+            assert length == 0
+            assert advice == os.POSIX_FADV_DONTNEED
+
+    def test_multiple_writes_advise_each_time(self, tmp_path: Path) -> None:
+        shard = _Shard(tmp_path / "test.bin", n_samples=4)
+        t1 = torch.randn(2, 8, dtype=torch.float32)
+        t2 = torch.randn(2, 8, dtype=torch.float32)
+
+        with patch("fpwap.storage.memmap.os.posix_fadvise") as mock_fadvise:
+            shard.write(torch.tensor([0, 1]), t1)
+            shard.write(torch.tensor([2, 3]), t2)
+            assert mock_fadvise.call_count == 2
+
+    def test_noop_when_posix_fadvise_unavailable(self, tmp_path: Path) -> None:
+        shard = _Shard(tmp_path / "test.bin", n_samples=4)
+        t = torch.randn(2, 8, dtype=torch.float32)
+
+        with patch("fpwap.storage.memmap._HAS_POSIX_FADVISE", False):
+            shard.write(torch.tensor([0, 1]), t)
+
+        got = shard.read()
+        assert torch.equal(got[0:2], t)
+
+    def test_oserror_is_silenced(self, tmp_path: Path) -> None:
+        shard = _Shard(tmp_path / "test.bin", n_samples=4)
+        t = torch.randn(2, 8, dtype=torch.float32)
+
+        with patch(
+            "fpwap.storage.memmap.os.posix_fadvise",
+            side_effect=OSError("not supported"),
+        ):
+            shard.write(torch.tensor([0, 1]), t)
+
+        got = shard.read()
+        assert torch.equal(got[0:2], t)
+
+    def test_roundtrip_still_correct(self, tmp_path: Path) -> None:
+        """Write + fadvise eviction doesn't corrupt data on read-back."""
+        shard = _Shard(tmp_path / "test.bin", n_samples=4)
+        t1 = torch.randn(2, 8, dtype=torch.float32)
+        t2 = torch.randn(2, 8, dtype=torch.float32)
+        shard.write(torch.tensor([0, 1]), t1)
+        shard.write(torch.tensor([2, 3]), t2)
+        got = shard.read()
+        assert torch.equal(got[0:2], t1)
+        assert torch.equal(got[2:4], t2)
+
+
+class TestMemmapBackendFadvise:
+    def test_write_emit_triggers_fadvise(self, tmp_path: Path) -> None:
+        backend = MemmapBackend(root=tmp_path)
+        backend.on_sweep_start("test", n_samples=4)
+        t = torch.randn(2, 8, dtype=torch.float32)
+
+        with patch("fpwap.storage.memmap.os.posix_fadvise") as mock_fadvise:
+            backend.write_emit(0, "residual_post", torch.tensor([0, 1]), t)
+            assert mock_fadvise.call_count == 1


### PR DESCRIPTION
## Summary

- Flush + `posix_fadvise(FADV_DONTNEED)` on emit shard pages after each `_Shard.write()`, so the kernel can reclaim them for weight and residual streaming
- Same pattern as #25 (`ShardPageAdvisor`) for weight shards — open read-only fd, advise, close; guarded by `_HAS_POSIX_FADVISE`, `OSError` silenced
- On 70B×10k sweeps capturing a single layer, this frees ~20 GB of page cache (~18% of budget on 128 GB hosts) that was previously pinned hot for the entire sweep duration

Closes #50

## Test plan

- [x] 6 new unit tests: fadvise called after write, called per-write, no-op without `posix_fadvise`, `OSError` silenced, data round-trip correct, end-to-end via `MemmapBackend.write_emit`
- [x] `ruff check` clean
- [x] `mypy` clean
- [ ] Existing integration tests (`test_memmap_backend.py`) pass on GPU host
- [ ] 70B sweep: verify per-layer s/it stops upward drift after first few layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)