### PR TITLE
Zero-copy memmap read: return OS-paged tensor instead of .copy()

### DIFF
--- a/src/fpwap/storage/memmap.py
+++ b/src/fpwap/storage/memmap.py
@@ -116,9 +116,10 @@ class _Shard:
             raise RuntimeError(f"shard {self.path.name!r} was never written to")
         self._mm.flush()
         arr = np.asarray(self._mm)
+        t = torch.from_numpy(arr)
         if self._stores_bf16_as_u16:
-            return torch.from_numpy(arr.copy()).view(torch.bfloat16)
-        return torch.from_numpy(arr.copy())
+            t = t.view(torch.bfloat16)
+        return t
 
     def flush(self) -> None:
         if self._mm is not None:

--- a/tests/unit/test_memmap_shard_zero_copy.py
+++ b/tests/unit/test_memmap_shard_zero_copy.py
@@ -1,0 +1,38 @@
+"""Unit tests: _Shard.read() must return a memmap-backed tensor, not a copy (#52).
+
+MemmapBackend exists so the full [N, S, H] corpus never lives in Python
+memory at once. A .copy() in read() defeats that — it materializes the
+entire shard in RAM, which OOMs when the shard is bigger than host memory.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from fpwap.storage.memmap import _Shard
+
+
+class TestShardReadZeroCopy:
+    def test_float32_shares_memory(self, tmp_path: Path) -> None:
+        shard = _Shard(tmp_path / "f32.bin", n_samples=4)
+        data = torch.randn(4, 8, dtype=torch.float32)
+        shard.write(torch.arange(4), data)
+
+        t = shard.read()
+        assert torch.equal(t, data)
+        assert np.shares_memory(t.numpy(), np.asarray(shard._mm))
+
+    def test_bf16_shares_memory(self, tmp_path: Path) -> None:
+        shard = _Shard(tmp_path / "bf16.bin", n_samples=4)
+        data = torch.randn(4, 8, dtype=torch.bfloat16)
+        shard.write(torch.arange(4), data)
+
+        t = shard.read()
+        assert t.dtype == torch.bfloat16
+        assert torch.equal(t, data)
+        # bf16 stored as uint16 on disk; view shares the same buffer
+        assert np.shares_memory(
+            t.view(torch.uint16).numpy(), np.asarray(shard._mm)
+        )


### PR DESCRIPTION
## Summary
- **Fixes #52** — `_Shard.read()` called `.copy()` on the memmap array, materializing the entire emit shard in RAM. This OOMed on any shard larger than host memory (e.g. 156 GiB on a 128 GB host), defeating the purpose of disk-backed storage.
- Returns a `torch.from_numpy(np.asarray(mm))` tensor that shares storage with the memmap. The OS pages in only what downstream code touches — no bulk allocation.
- Both float32 and bf16-as-uint16 paths are zero-copy.

## Test plan
- [x] New unit tests (`test_memmap_shard_zero_copy.py`) verify `np.shares_memory` between the returned tensor and the underlying memmap for both float32 and bf16
- [x] Existing memmap round-trip tests pass (integration + fadvise)
- [x] Full CI-safe suite (123 tests) passes with no regressions
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)