### PR TITLE
Teardown sub-phase profiling and progress events (#54)

### DIFF
--- a/src/fpwap/__init__.py
+++ b/src/fpwap/__init__.py
@@ -1,5 +1,12 @@
 from fpwap.callbacks.base import Callback
-from fpwap.engine import ProfileReport, Result, SetupTiming, Sweep, estimate_max_microbatch
+from fpwap.engine import (
+    ProfileReport,
+    Result,
+    SetupTiming,
+    Sweep,
+    TeardownTiming,
+    estimate_max_microbatch,
+)
 from fpwap.extractor import Extractor
 from fpwap.preflight import PreflightReport
 from fpwap.types import (
@@ -24,6 +31,7 @@ __all__ = [
     "Result",
     "SetupTiming",
     "Sweep",
+    "TeardownTiming",
     "WriteBack",
     "estimate_max_microbatch",
 ]

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import time
 import uuid
 from collections.abc import Callable, Iterable, Sequence
@@ -80,6 +81,21 @@ class SetupTiming:
 
 
 @dataclass
+class TeardownTiming:
+    """Breakdown of the teardown phase after the main loop completes.
+
+    Captures where wall-clock goes during streamer shutdown, callback
+    finalization, residual buffer flush, and storage backend flush.
+    """
+
+    streamer_close_s: float = 0.0
+    callbacks_s: float = 0.0
+    buffer_flush_s: float = 0.0
+    storage_flush_s: float = 0.0
+    total_s: float = 0.0
+
+
+@dataclass
 class ProfileReport:
     """Always-on profile of an fpwap run. Target overhead: < 1% wall-clock.
 
@@ -93,7 +109,13 @@ class ProfileReport:
     setup: SetupTiming | None = None
     embed_s: float = 0.0
     loop_s: float = 0.0
-    teardown_s: float = 0.0
+    teardown: TeardownTiming | None = None
+
+    @property
+    def teardown_s(self) -> float:
+        if self.teardown is None:
+            return 0.0
+        return self.teardown.total_s
 
     def throughput_tok_per_s(self) -> float:
         """End-to-end tokens per second — total tokens (N * seq_len) divided
@@ -133,8 +155,19 @@ class ProfileReport:
             lines.append(f"  embed {self.embed_s:.3f}s")
         if self.loop_s > 0:
             lines.append(f"  loop  {self.loop_s:.3f}s")
-        if self.teardown_s > 0:
-            lines.append(f"  teardown {self.teardown_s:.3f}s")
+        if self.teardown is not None and self.teardown.total_s > 0:
+            td = self.teardown
+            parts: list[str] = []
+            for name, val in [
+                ("streamer_close", td.streamer_close_s),
+                ("callbacks", td.callbacks_s),
+                ("buffer_flush", td.buffer_flush_s),
+                ("storage_flush", td.storage_flush_s),
+            ]:
+                if val > 0:
+                    parts.append(f"{name} {val:.3f}s")
+            detail = f"  ({', '.join(parts)})" if parts else ""
+            lines.append(f"  teardown {td.total_s:.3f}s{detail}")
         for i, t in sorted(self.per_layer.items()):
             lines.append(
                 f"  layer {i}: load {t.load_s:.3f}s  fwd {t.forward_s:.3f}s  "
@@ -1378,21 +1411,57 @@ class Sweep:
 
         loop_s = (time.perf_counter_ns() - t0_loop) / 1e9
 
-        # Drain the prefetch pool so the worker thread exits cleanly.
+        # --- Teardown: timed per sub-phase, with progress events ---
+        td = TeardownTiming()
         t0_teardown = time.perf_counter_ns()
-        streamer.close()
 
+        _emit_progress("teardown_streamer_close", -1, 0, 0)
+        if self.progress is True:
+            sys.stderr.write("fpwap: flushing (streamer close)...\n")
+            sys.stderr.flush()
+        t0 = time.perf_counter_ns()
+        streamer.close()
+        td.streamer_close_s = (time.perf_counter_ns() - t0) / 1e9
+
+        _emit_progress("teardown_callbacks", -1, 0, 0)
+        if self.progress is True:
+            sys.stderr.write("fpwap: flushing (callbacks)...\n")
+            sys.stderr.flush()
+        t0 = time.perf_counter_ns()
         artifacts: dict[tuple[str, int], Artifact] = dict(layer_artifacts)
         for cb in self.callbacks:
             art = cb.on_sweep_end()
             if art is not None:
                 artifacts[(art.key.kind, art.key.layer_idx)] = art
+        td.callbacks_s = (time.perf_counter_ns() - t0) / 1e9
 
+        _emit_progress("teardown_buffer_flush", -1, 0, 0)
+        if self.progress is True:
+            sys.stderr.write("fpwap: flushing (residual buffer)...\n")
+            sys.stderr.flush()
+        t0 = time.perf_counter_ns()
         for seg in segments:
             seg.buffer.flush()
+        td.buffer_flush_s = (time.perf_counter_ns() - t0) / 1e9
+
+        _emit_progress("teardown_storage_flush", -1, 0, 0)
+        if self.progress is True:
+            sys.stderr.write("fpwap: flushing (storage backend)...\n")
+            sys.stderr.flush()
+        t0 = time.perf_counter_ns()
         if self.storage is not None:
             self.storage.on_sweep_end()
-        teardown_s = (time.perf_counter_ns() - t0_teardown) / 1e9
+        td.storage_flush_s = (time.perf_counter_ns() - t0) / 1e9
+
+        td.total_s = (time.perf_counter_ns() - t0_teardown) / 1e9
+        _emit_progress("teardown_end", -1, 0, 0)
+        if self.progress is True:
+            sys.stderr.write(
+                f"fpwap: teardown complete ({td.total_s:.1f}s: "
+                f"buffer_flush {td.buffer_flush_s:.1f}s, "
+                f"storage_flush {td.storage_flush_s:.1f}s)\n"
+            )
+            sys.stderr.flush()
 
         profile.total_wall_s = (time.perf_counter_ns() - t0_run) / 1e9
         profile.total_tokens = sum(
@@ -1401,7 +1470,7 @@ class Sweep:
         profile.setup = setup_timing
         profile.embed_s = embed_s
         profile.loop_s = loop_s
-        profile.teardown_s = teardown_s
+        profile.teardown = td
         return Result(
             sweep_id=sweep_id,
             artifacts=artifacts,

--- a/tests/integration/test_teardown_progress.py
+++ b/tests/integration/test_teardown_progress.py
@@ -1,0 +1,96 @@
+"""Callable progress reporter receives teardown-phase events.
+
+After the last layer_end, the reporter should receive events for each
+teardown sub-phase so users/integrators have visibility into finalization.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from fpwap.engine import ProgressEvent
+
+SEED = 0
+N_SAMPLES = 4
+SEQ_LEN = 4
+HIDDEN = 8
+N_LAYERS = 2
+
+
+def _tiny_gpt2() -> torch.nn.Module:
+    from transformers import GPT2Config, GPT2LMHeadModel
+
+    config = GPT2Config(
+        vocab_size=16,
+        n_positions=SEQ_LEN,
+        n_embd=HIDDEN,
+        n_layer=N_LAYERS,
+        n_head=2,
+    )
+    torch.manual_seed(SEED)
+    model = GPT2LMHeadModel(config)
+    model.eval()
+    return model
+
+
+@pytest.mark.integration
+def test_teardown_events_emitted() -> None:
+    from fpwap import Sweep
+
+    events: list[ProgressEvent] = []
+
+    sweep = Sweep(
+        model=_tiny_gpt2(),
+        dataset=[
+            {"input_ids": torch.randint(0, 16, (1, SEQ_LEN))} for _ in range(N_SAMPLES)
+        ],
+        seq_len=SEQ_LEN,
+        callbacks=[],
+        transport_dtype=torch.float32,
+        microbatch_size=2,
+        seed=SEED,
+        progress=events.append,
+    )
+    sweep.run()
+
+    teardown_events = [e for e in events if e.kind.startswith("teardown")]
+    assert len(teardown_events) >= 1, "expected at least one teardown progress event"
+
+    teardown_kinds = [e.kind for e in teardown_events]
+    assert "teardown_buffer_flush" in teardown_kinds
+    assert "teardown_end" in teardown_kinds
+
+    last_layer_end = max(
+        i for i, e in enumerate(events) if e.kind == "layer_end"
+    )
+    first_teardown = min(
+        i for i, e in enumerate(events) if e.kind.startswith("teardown")
+    )
+    assert first_teardown > last_layer_end
+
+    walls = [e.wall_s for e in events]
+    assert walls == sorted(walls)
+
+
+@pytest.mark.integration
+def test_profile_teardown_is_teardown_timing() -> None:
+    from fpwap import Sweep
+    from fpwap.engine import TeardownTiming
+
+    sweep = Sweep(
+        model=_tiny_gpt2(),
+        dataset=[
+            {"input_ids": torch.randint(0, 16, (1, SEQ_LEN))} for _ in range(N_SAMPLES)
+        ],
+        seq_len=SEQ_LEN,
+        callbacks=[],
+        transport_dtype=torch.float32,
+        microbatch_size=2,
+        seed=SEED,
+        progress=False,
+    )
+    result = sweep.run()
+
+    assert isinstance(result.profile.teardown, TeardownTiming)
+    assert result.profile.teardown.total_s > 0
+    assert result.profile.teardown_s == result.profile.teardown.total_s

--- a/tests/unit/test_setup_timing.py
+++ b/tests/unit/test_setup_timing.py
@@ -1,7 +1,7 @@
 """Unit tests for SetupTiming and full-phase ProfileReport profiling."""
 from __future__ import annotations
 
-from fpwap.engine import LayerTiming, ProfileReport, SetupTiming
+from fpwap.engine import LayerTiming, ProfileReport, SetupTiming, TeardownTiming
 
 
 def test_setup_timing_fields() -> None:
@@ -45,7 +45,7 @@ def test_profile_report_phases_attached() -> None:
         total_tokens=1000,
         embed_s=0.5,
         loop_s=8.0,
-        teardown_s=0.1,
+        teardown=TeardownTiming(total_s=0.1),
     )
     assert r.embed_s == 0.5
     assert r.loop_s == 8.0
@@ -84,7 +84,7 @@ def test_summary_includes_embed_and_loop() -> None:
         per_layer={0: LayerTiming()},
         embed_s=0.5,
         loop_s=8.0,
-        teardown_s=0.1,
+        teardown=TeardownTiming(total_s=0.1),
     )
     s = r.summary()
     assert "embed 0.500s" in s

--- a/tests/unit/test_teardown_timing.py
+++ b/tests/unit/test_teardown_timing.py
@@ -1,0 +1,87 @@
+"""Unit tests for TeardownTiming sub-phase breakdown in ProfileReport."""
+from __future__ import annotations
+
+from fpwap.engine import LayerTiming, ProfileReport, TeardownTiming
+
+
+def test_teardown_timing_fields() -> None:
+    t = TeardownTiming(
+        streamer_close_s=0.01,
+        callbacks_s=0.05,
+        buffer_flush_s=12.3,
+        storage_flush_s=4.5,
+        total_s=16.86,
+    )
+    assert t.streamer_close_s == 0.01
+    assert t.callbacks_s == 0.05
+    assert t.buffer_flush_s == 12.3
+    assert t.storage_flush_s == 4.5
+    assert t.total_s == 16.86
+
+
+def test_teardown_timing_defaults() -> None:
+    t = TeardownTiming()
+    assert t.streamer_close_s == 0.0
+    assert t.callbacks_s == 0.0
+    assert t.buffer_flush_s == 0.0
+    assert t.storage_flush_s == 0.0
+    assert t.total_s == 0.0
+
+
+def test_profile_report_teardown_is_teardown_timing() -> None:
+    td = TeardownTiming(buffer_flush_s=5.0, total_s=5.0)
+    r = ProfileReport(total_wall_s=10.0, total_tokens=100, teardown=td)
+    assert r.teardown is td
+    assert r.teardown_s == 5.0
+
+
+def test_teardown_s_backward_compat_default() -> None:
+    """teardown_s returns 0.0 when no teardown timing is attached."""
+    r = ProfileReport(total_wall_s=1.0, total_tokens=100)
+    assert r.teardown_s == 0.0
+
+
+def test_summary_shows_teardown_subphases() -> None:
+    td = TeardownTiming(
+        streamer_close_s=0.01,
+        callbacks_s=0.02,
+        buffer_flush_s=12.0,
+        storage_flush_s=4.0,
+        total_s=16.03,
+    )
+    r = ProfileReport(
+        total_wall_s=30.0,
+        total_tokens=1000,
+        per_layer={0: LayerTiming()},
+        teardown=td,
+    )
+    s = r.summary()
+    assert "teardown 16.030s" in s
+    assert "buffer_flush 12.000s" in s
+    assert "storage_flush 4.000s" in s
+
+
+def test_summary_omits_zero_teardown_subphases() -> None:
+    td = TeardownTiming(buffer_flush_s=5.0, total_s=5.0)
+    r = ProfileReport(
+        total_wall_s=10.0,
+        total_tokens=100,
+        per_layer={0: LayerTiming()},
+        teardown=td,
+    )
+    s = r.summary()
+    assert "teardown 5.000s" in s
+    assert "buffer_flush 5.000s" in s
+    assert "streamer_close" not in s
+    assert "callbacks" not in s
+    assert "storage_flush" not in s
+
+
+def test_summary_omits_teardown_when_zero() -> None:
+    r = ProfileReport(
+        total_wall_s=5.0,
+        total_tokens=100,
+        per_layer={0: LayerTiming()},
+    )
+    s = r.summary()
+    assert "teardown" not in s


### PR DESCRIPTION
## Summary

- Replaces the opaque `teardown_s` scalar with `TeardownTiming` dataclass that breaks teardown into four timed sub-phases: `streamer_close_s`, `callbacks_s`, `buffer_flush_s`, `storage_flush_s`
- Emits `teardown_*` `ProgressEvent`s for callable reporters so integrators have visibility into finalization
- Prints stderr status lines during teardown when `progress=True` (tqdm mode) so users see activity instead of silence
- `profile.summary()` now renders teardown sub-phase breakdown (only non-zero phases shown)
- Backward-compatible: `profile.teardown_s` remains accessible as a property returning `teardown.total_s`

Closes #54

## Test plan

- [x] Unit tests for `TeardownTiming` fields, defaults, and `ProfileReport` integration (`tests/unit/test_teardown_timing.py`)
- [x] Existing `test_setup_timing.py` tests updated for new `teardown=TeardownTiming(...)` constructor
- [x] Integration test verifying callable reporter receives `teardown_buffer_flush` and `teardown_end` events after last `layer_end` (`tests/integration/test_teardown_progress.py`)
- [x] Integration test verifying `result.profile.teardown` is a `TeardownTiming` instance with `total_s > 0`
- [x] All 130 unit tests pass, ruff clean, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)