### PR TITLE
Stream emit to a stable path via Result.activations(as_path=...) (#70)

### DIFF
--- a/src/fpwap/__init__.py
+++ b/src/fpwap/__init__.py
@@ -17,6 +17,7 @@ from fpwap.types import (
     Emit,
     LayerArtifact,
     RaggedTensor,
+    ResultArtifact,
     WriteBack,
 )
 
@@ -33,6 +34,7 @@ __all__ = [
     "ProfileReport",
     "RaggedTensor",
     "Result",
+    "ResultArtifact",
     "SetupTiming",
     "Sweep",
     "TeardownTiming",

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -321,6 +321,19 @@ class Result:
                 pointing there. Backend keeps ownership of its original.
                 Requires a StorageBackend; raises otherwise.
         """
+        # Catch both `as_path=""` (falsy — would silently fall through to
+        # the in-memory branch and confuse the caller) and `as_path=Path("")`
+        # (truthy — would resolve to cwd and hardlink into the working dir).
+        # Path("").parts is () — distinguishes the empty Path from explicit
+        # Path(".") which a caller might genuinely intend.
+        if (
+            (isinstance(as_path, str) and not as_path)
+            or (isinstance(as_path, Path) and not as_path.parts)
+        ):
+            raise ValueError(
+                f"as_path string/Path must be non-empty (got {as_path!r}); "
+                "pass True for an in-place handle or an actual path"
+            )
         if as_path:
             if self.storage is None:
                 raise RuntimeError(

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -31,6 +31,7 @@ from fpwap.types import (
     LoadingStrategy,
     PaddingMode,
     RaggedTensor,
+    ResultArtifact,
     WriteBack,
 )
 
@@ -292,7 +293,13 @@ class Result:
     def artifact(self, kind: str, layer: int) -> Artifact:
         return self.artifacts[(kind, layer)]
 
-    def activations(self, layer: int, hook: HookName) -> Tensor | RaggedTensor:
+    def activations(
+        self,
+        layer: int,
+        hook: HookName,
+        *,
+        as_path: bool | str | Path = False,
+    ) -> Tensor | RaggedTensor | ResultArtifact:
         """Concatenate emitted activations for (layer, hook) in sample-id order.
 
         Requires at least one read-phase callback (e.g. RawActivations) to have
@@ -304,7 +311,25 @@ class Result:
         `RaggedTensor(flat, offsets)` when the callback supplied
         `Emit.sample_lengths`. Callers that may receive either layout must
         dispatch on `isinstance(result, RaggedTensor)`.
+
+        Args:
+            as_path: If False (default), return the materialized tensor.
+                If True, return a `ResultArtifact` pointing at the backend's
+                in-place file (caller mmap-reads on demand — issue #70).
+                If a Path/str, hardlink (or copy on EXDEV) the data file
+                and sidecar into that directory and return a `ResultArtifact`
+                pointing there. Backend keeps ownership of its original.
+                Requires a StorageBackend; raises otherwise.
         """
+        if as_path:
+            if self.storage is None:
+                raise RuntimeError(
+                    "activations(as_path=...) requires a StorageBackend on "
+                    "the Sweep; no backend is wired so there is no on-disk "
+                    "file to hand out"
+                )
+            dest = Path(as_path) if not isinstance(as_path, bool) else None
+            return self.storage.path_for(layer, hook, dest=dest)
         if self.storage is not None:
             return self.storage.read_all(layer, hook)
         key = (layer, hook)

--- a/src/fpwap/storage/__init__.py
+++ b/src/fpwap/storage/__init__.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Protocol
 
 from torch import Tensor
 
-from fpwap.types import HookName, RaggedTensor
+from fpwap.types import HookName, RaggedTensor, ResultArtifact
 
 
 class StorageBackend(Protocol):
@@ -48,6 +49,30 @@ class StorageBackend(Protocol):
     def drain_emits(self) -> None: ...
 
     def on_sweep_end(self) -> None: ...
+
+    def path_for(
+        self,
+        layer_idx: int,
+        hook: HookName,
+        dest: Path | None = None,
+    ) -> ResultArtifact:
+        """Return an on-disk handle for one (layer, hook), bypassing the
+        materialize-into-RAM round-trip in `read_all` (issue #70).
+
+        Modes:
+            * `dest=None` — return a handle pointing at the backend's own
+              file. Caller mmap-reads on demand. Backend retains ownership;
+              the file lifetime is tied to the backend (e.g. a sweep
+              cleanup may delete it later).
+            * `dest=Path(dir)` — hardlink (fallback to copy on EXDEV) the
+              data file and its sidecar into `dir`, and return a handle
+              pointing at the hardlinked copy. Backend keeps the original.
+              Caller owns `dir` and decides when to delete.
+
+        Backends MUST flush pending writes (e.g. drain staging buffers,
+        finalize ragged shards) before returning so the file is readable.
+        """
+        ...
 
 
 __all__ = ["StorageBackend"]

--- a/src/fpwap/storage/memmap.py
+++ b/src/fpwap/storage/memmap.py
@@ -12,8 +12,10 @@ on the SPEC §17 target workload (Llama-70B × 10k prompts × 128 tokens ≈
 """
 from __future__ import annotations
 
+import errno
 import json
 import os
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -21,7 +23,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from fpwap.types import HookName, RaggedTensor
+from fpwap.types import HookName, RaggedTensor, ResultArtifact
 
 _HAS_POSIX_FADVISE = hasattr(os, "posix_fadvise")
 
@@ -552,3 +554,83 @@ class MemmapBackend:
         # file for each ragged shard and drop its .raw.bin scratch.
         for shard in self._shards.values():
             shard.finalize()
+
+    def path_for(
+        self,
+        layer_idx: int,
+        hook: HookName,
+        dest: Path | None = None,
+    ) -> ResultArtifact:
+        """Return an on-disk handle for one (layer, hook) — issue #70.
+
+        Skips the materialize-into-host-RAM round-trip in `read_all`. Useful
+        when the caller already plans to mmap-read or move the file
+        (cumulative emits across sweeps that won't fit in RAM).
+        """
+        key = (layer_idx, hook)
+        if key not in self._shards:
+            raise KeyError(
+                f"no emits recorded for layer={layer_idx} hook={hook!r}"
+            )
+        shard = self._shards[key]
+
+        # Make the on-disk artifact readable: drain pending staged writes,
+        # and for ragged build the final sample-id-ordered .bin + offsets
+        # sidecar. Mid-sweep callers may hit this before on_sweep_end.
+        shard.drain()
+        if shard._layout == "ragged":
+            shard._build_final_ragged()
+        elif shard._mm is None:
+            raise RuntimeError(
+                f"shard {shard.path.name!r} was never written to"
+            )
+        else:
+            shard._mm.flush()
+
+        data_path: Path = shard.path
+        sidecar_path: Path | None = shard.path.with_suffix(".json")
+        layout: str = shard._layout or "dense"
+        assert shard.torch_dtype is not None
+        dtype = shard.torch_dtype
+        shape: tuple[int, ...] | None
+        if layout == "dense":
+            assert shard.per_row_shape is not None
+            shape = (shard.n_samples, *shard.per_row_shape)
+        else:
+            shape = None
+
+        if dest is not None:
+            dest = Path(dest)
+            dest.mkdir(parents=True, exist_ok=True)
+            data_path = _link_or_copy(shard.path, dest / shard.path.name)
+            src_sidecar = shard.path.with_suffix(".json")
+            sidecar_path = _link_or_copy(
+                src_sidecar, dest / src_sidecar.name
+            ) if src_sidecar.exists() else None
+
+        return ResultArtifact(
+            data_path=data_path,
+            sidecar_path=sidecar_path,
+            layout=layout,  # type: ignore[arg-type]
+            dtype=dtype,
+            shape=shape,
+        )
+
+
+def _link_or_copy(src: Path, dst: Path) -> Path:
+    """Hardlink src → dst; fall back to copy on EXDEV (cross-filesystem).
+
+    Hardlink is the cheap path: backend keeps writing into its file, the
+    user holds a separate path with the same inode. If the destination
+    is on another filesystem the kernel rejects the link with EXDEV; copy
+    is the only option there.
+    """
+    if dst.exists():
+        dst.unlink()
+    try:
+        os.link(src, dst)
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            raise
+        shutil.copy2(src, dst)
+    return dst

--- a/src/fpwap/storage/memmap.py
+++ b/src/fpwap/storage/memmap.py
@@ -566,6 +566,25 @@ class MemmapBackend:
         Skips the materialize-into-host-RAM round-trip in `read_all`. Useful
         when the caller already plans to mmap-read or move the file
         (cumulative emits across sweeps that won't fit in RAM).
+
+        Mid-sweep stability caveat: dest hardlinks share the inode with the
+        backend's file. Until `on_sweep_end()` finalizes the shard, that
+        inode is still being mutated:
+
+        * dense: a hardlink read mid-sweep sees in-progress writes (rows
+          for samples not yet emitted are zero-filled). Non-destructive.
+        * ragged: a subsequent drain after more samples arrive may rebuild
+          the final .bin via `mode="w+"` (memmap.py:362-368), which
+          truncates the inode — your hardlinked dest file gets trashed.
+
+        Content is stable only after `on_sweep_end()`. For per-sweep K-sweep
+        slicing (the workflow issue #70 motivates), call `path_for(dest=...)`
+        after the sweep ends — at that point ragged is finalized and the
+        cross-device-copy fallback path keeps the dest file intact regardless.
+
+        On dest collision (a file with the same name already exists in
+        `dest`): raises `FileExistsError`. Callers should use a fresh dest
+        dir per `path_for` call, or clean up the old file themselves.
         """
         key = (layer_idx, hook)
         if key not in self._shards:
@@ -584,8 +603,6 @@ class MemmapBackend:
             raise RuntimeError(
                 f"shard {shard.path.name!r} was never written to"
             )
-        else:
-            shard._mm.flush()
 
         data_path: Path = shard.path
         sidecar_path: Path | None = shard.path.with_suffix(".json")
@@ -624,9 +641,14 @@ def _link_or_copy(src: Path, dst: Path) -> Path:
     user holds a separate path with the same inode. If the destination
     is on another filesystem the kernel rejects the link with EXDEV; copy
     is the only option there.
+
+    Raises FileExistsError if `dst` already exists — surfacing the
+    collision is preferable to silently clobbering a previous handle the
+    caller may still be reading. The check is explicit so the cross-FS
+    copy path matches the same-FS hardlink path's semantics.
     """
     if dst.exists():
-        dst.unlink()
+        raise FileExistsError(dst)
     try:
         os.link(src, dst)
     except OSError as exc:

--- a/src/fpwap/types.py
+++ b/src/fpwap/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
 import torch
@@ -80,3 +81,34 @@ class Context:
     seq_len: int
     hidden: int
     transport_dtype: torch.dtype
+
+
+@dataclass(frozen=True)
+class ResultArtifact:
+    """On-disk handle returned by `Result.activations(..., as_path=True)`.
+
+    Lets a caller skip materializing the emit into a host-RAM tensor when
+    the consumer is going to read from disk anyway. The data file is
+    backend-owned (in-place mode) or hardlinked/copied into a user dir
+    (dest mode); ownership is never transferred.
+
+    Fields:
+        data_path:    The shard `.bin` file. mmap-readable.
+        sidecar_path: The `.json` sidecar with shape/dtype (and per-sample
+                      offsets for ragged). None only if a backend chose
+                      not to write one.
+        layout:       "dense" → `data_path` is `[N_samples, *per_row_shape]`.
+                      "ragged" → flat `[total_tokens, *trailing]`; per-sample
+                      offsets live in the sidecar.
+        dtype:        Logical torch dtype of the on-disk tensor. bf16 is
+                      stored as uint16 on disk; the sidecar `bf16_as_u16`
+                      flag tells you to `.view(torch.bfloat16)` after read.
+        shape:        Full tensor shape for dense; None for ragged (use
+                      sidecar offsets / `RaggedTensor.lengths`).
+    """
+
+    data_path: Path
+    sidecar_path: Path | None
+    layout: Literal["dense", "ragged"]
+    dtype: torch.dtype
+    shape: tuple[int, ...] | None

--- a/tests/integration/test_activations_as_path.py
+++ b/tests/integration/test_activations_as_path.py
@@ -1,0 +1,279 @@
+"""Result.activations(..., as_path=...) — issue #70.
+
+Avoids materializing the emit into a host-RAM tensor when the consumer
+already wants a disk handle. Two modes:
+
+* `as_path=True` — return a `ResultArtifact` pointing at the backend's
+  in-place file (caller mmap-reads on demand).
+* `as_path=Path(dest_dir)` — hardlink (or copy on EXDEV) the data .bin
+  and the .json sidecar into `dest_dir`; return a `ResultArtifact`
+  pointing at the new location. Backend keeps its original — ownership
+  is *not* transferred.
+
+Both modes return the same dataclass shape, so callers can ignore the
+distinction.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from torch import Tensor
+
+from fpwap import Callback, Emit
+from fpwap.types import HookName
+
+SEED = 0
+N_SAMPLES = 6
+SEQ_LEN = 8
+HIDDEN = 16
+N_LAYERS = 2
+N_HEAD = 2
+VOCAB = 100
+
+
+def _tiny_gpt2() -> torch.nn.Module:
+    from transformers import GPT2Config, GPT2LMHeadModel
+
+    config = GPT2Config(
+        vocab_size=VOCAB,
+        n_positions=SEQ_LEN,
+        n_embd=HIDDEN,
+        n_layer=N_LAYERS,
+        n_head=N_HEAD,
+    )
+    torch.manual_seed(SEED)
+    model = GPT2LMHeadModel(config)
+    model.eval()
+    return model
+
+
+def _dataset() -> list[dict[str, Tensor]]:
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, VOCAB, (N_SAMPLES, SEQ_LEN))
+    return [{"input_ids": input_ids[i : i + 1]} for i in range(N_SAMPLES)]
+
+
+def _per_sample_keep_lengths(n: int, seq: int) -> list[int]:
+    return [min(i + 1, seq) for i in range(n)]
+
+
+class _RaggedKeepFromTail(Callback):
+    def __init__(self, keep: list[int]) -> None:
+        self.keep = keep
+
+    def on_batch(
+        self,
+        layer_idx: int,
+        hook: HookName,
+        acts: Tensor,
+        sample_ids: Tensor,
+    ) -> Emit:
+        sids = sample_ids.detach().cpu().tolist()
+        chunks = []
+        lens = []
+        for row, sid in enumerate(sids):
+            k = self.keep[sid]
+            chunks.append(acts[row, -k:, :].detach().to(torch.float32).cpu())
+            lens.append(k)
+        flat = torch.cat(chunks, dim=0)
+        return Emit(
+            tensor=flat,
+            sample_lengths=torch.tensor(lens, dtype=torch.int64),
+        )
+
+
+def _read_dense_memmap(path: Path, sidecar: Path) -> Tensor:
+    """Mirror of MemmapBackend's read path, used to verify ResultArtifact
+    points at a self-describing on-disk artifact (no fpwap calls)."""
+    meta = json.loads(sidecar.read_text())
+    per_row = tuple(meta["per_row_shape"])
+    n_samples = int(meta["n_samples"])
+    bf16_as_u16 = bool(meta.get("bf16_as_u16", False))
+    np_dtype = np.uint16 if bf16_as_u16 else np.dtype(meta["dtype"])
+    mm = np.memmap(path, dtype=np_dtype, mode="r", shape=(n_samples, *per_row))
+    t = torch.from_numpy(np.asarray(mm))
+    if bf16_as_u16:
+        t = t.view(torch.bfloat16)
+    return t
+
+
+@pytest.mark.integration
+def test_as_path_dense_inplace(tmp_path: Path) -> None:
+    """as_path=True returns a ResultArtifact pointing at the backend's
+    file; mmap-reading it gives the same tensor as activations() would."""
+    from fpwap import ResultArtifact, Sweep
+    from fpwap.callbacks.common import RawActivations
+    from fpwap.storage.memmap import MemmapBackend
+
+    model = _tiny_gpt2()
+    backend_root = tmp_path / "backend"
+    backend = MemmapBackend(root=backend_root)
+    result = Sweep(
+        model=model,
+        dataset=_dataset(),
+        seq_len=SEQ_LEN,
+        callbacks=[
+            RawActivations(layers="all", last_token_only=False, out_dtype=torch.float32)
+        ],
+        transport_dtype=torch.float32,
+        microbatch_size=2,
+        seed=SEED,
+        progress=False,
+        storage=backend,
+    ).run()
+
+    art = result.activations(layer=0, hook="residual_post", as_path=True)
+    assert isinstance(art, ResultArtifact)
+    assert art.layout == "dense"
+    assert art.shape == (N_SAMPLES, SEQ_LEN, HIDDEN)
+    assert art.dtype == torch.float32
+    assert art.data_path.exists()
+    assert art.data_path.parent == backend_root
+    assert art.sidecar_path is not None and art.sidecar_path.exists()
+
+    # Self-describing: a third party can mmap-read with only the artifact.
+    via_path = _read_dense_memmap(art.data_path, art.sidecar_path)
+    via_tensor = result.activations(layer=0, hook="residual_post")
+    assert torch.equal(via_path, via_tensor)
+
+
+@pytest.mark.integration
+def test_as_path_dense_hardlink_to_dest(tmp_path: Path) -> None:
+    """as_path=Path(dest_dir) hardlinks data + sidecar into dest_dir;
+    backend keeps ownership of the original."""
+    from fpwap import ResultArtifact, Sweep
+    from fpwap.callbacks.common import RawActivations
+    from fpwap.storage.memmap import MemmapBackend
+
+    model = _tiny_gpt2()
+    backend_root = tmp_path / "backend"
+    dest = tmp_path / "user_dest"
+    dest.mkdir()
+    backend = MemmapBackend(root=backend_root)
+    result = Sweep(
+        model=model,
+        dataset=_dataset(),
+        seq_len=SEQ_LEN,
+        callbacks=[
+            RawActivations(layers="all", last_token_only=False, out_dtype=torch.float32)
+        ],
+        transport_dtype=torch.float32,
+        microbatch_size=2,
+        seed=SEED,
+        progress=False,
+        storage=backend,
+    ).run()
+
+    art = result.activations(
+        layer=1, hook="residual_post", as_path=dest
+    )
+    assert isinstance(art, ResultArtifact)
+    assert art.data_path.parent == dest
+    assert art.sidecar_path is not None and art.sidecar_path.parent == dest
+
+    # Backend's original still exists (ownership not transferred).
+    backend_files = list(backend_root.glob("layer_0001_residual_post.*"))
+    assert any(p.suffix == ".bin" for p in backend_files)
+    assert any(p.suffix == ".json" for p in backend_files)
+
+    # Hardlinked data file shares an inode with the backend file (cheap).
+    backend_bin = backend_root / "layer_0001_residual_post.bin"
+    if backend_bin.stat().st_dev == art.data_path.stat().st_dev:
+        # Same filesystem — hardlink expected.
+        assert backend_bin.stat().st_ino == art.data_path.stat().st_ino
+
+    # Either way, contents match.
+    via_path = _read_dense_memmap(art.data_path, art.sidecar_path)
+    via_tensor = result.activations(layer=1, hook="residual_post")
+    assert torch.equal(via_path, via_tensor)
+
+
+@pytest.mark.integration
+def test_as_path_ragged_inplace(tmp_path: Path) -> None:
+    """Ragged shards: ResultArtifact has layout='ragged', shape=None,
+    sidecar carries per-sample offsets so the file is self-describing."""
+    from fpwap import RaggedTensor, ResultArtifact, Sweep
+    from fpwap.storage.memmap import MemmapBackend
+
+    model = _tiny_gpt2()
+    keep = _per_sample_keep_lengths(N_SAMPLES, SEQ_LEN)
+    backend_root = tmp_path / "backend"
+    backend = MemmapBackend(root=backend_root)
+    result = Sweep(
+        model=model,
+        dataset=_dataset(),
+        seq_len=SEQ_LEN,
+        callbacks=[_RaggedKeepFromTail(keep)],
+        transport_dtype=torch.float32,
+        microbatch_size=2,
+        seed=SEED,
+        progress=False,
+        storage=backend,
+    ).run()
+
+    art = result.activations(layer=0, hook="residual_post", as_path=True)
+    assert isinstance(art, ResultArtifact)
+    assert art.layout == "ragged"
+    assert art.shape is None
+    assert art.data_path.exists()
+    assert art.sidecar_path is not None and art.sidecar_path.exists()
+
+    meta = json.loads(art.sidecar_path.read_text())
+    assert meta["layout"] == "ragged"
+    assert meta["offsets"][-1] == sum(keep)
+    assert meta["offsets"][0] == 0
+    assert len(meta["offsets"]) == N_SAMPLES + 1
+
+    # The in-place read still works through the normal accessor.
+    rt = result.activations(layer=0, hook="residual_post")
+    assert isinstance(rt, RaggedTensor)
+    assert int(rt.offsets[-1].item()) == sum(keep)
+
+
+@pytest.mark.integration
+def test_as_path_ragged_hardlink_to_dest(tmp_path: Path) -> None:
+    """Dest mode for ragged: both data and sidecar (with offsets) move
+    together so the destination is self-describing."""
+    from fpwap import ResultArtifact, Sweep
+    from fpwap.storage.memmap import MemmapBackend
+
+    model = _tiny_gpt2()
+    keep = _per_sample_keep_lengths(N_SAMPLES, SEQ_LEN)
+    backend_root = tmp_path / "backend"
+    dest = tmp_path / "user_dest"
+    dest.mkdir()
+    backend = MemmapBackend(root=backend_root)
+    result = Sweep(
+        model=model,
+        dataset=_dataset(),
+        seq_len=SEQ_LEN,
+        callbacks=[_RaggedKeepFromTail(keep)],
+        transport_dtype=torch.float32,
+        microbatch_size=2,
+        seed=SEED,
+        progress=False,
+        storage=backend,
+    ).run()
+
+    art = result.activations(layer=1, hook="residual_post", as_path=dest)
+    assert isinstance(art, ResultArtifact)
+    assert art.data_path.parent == dest
+    assert art.sidecar_path is not None and art.sidecar_path.parent == dest
+    meta = json.loads(art.sidecar_path.read_text())
+    assert meta["layout"] == "ragged"
+    assert meta["offsets"][-1] == sum(keep)
+
+
+def test_as_path_without_storage_raises() -> None:
+    """No backend → no on-disk file to point at. Make the failure mode
+    explicit instead of returning a misleading in-memory tensor wrapped
+    in a fake path."""
+    from fpwap.engine import Result
+
+    res = Result(sweep_id="x")
+    with pytest.raises((RuntimeError, ValueError)):
+        res.activations(layer=0, hook="residual_post", as_path=True)

--- a/tests/integration/test_activations_as_path.py
+++ b/tests/integration/test_activations_as_path.py
@@ -101,6 +101,29 @@ def _read_dense_memmap(path: Path, sidecar: Path) -> Tensor:
     return t
 
 
+def _read_ragged_memmap(path: Path, sidecar: Path):
+    """Reconstruct a RaggedTensor from `(data_path, sidecar_path)` alone.
+
+    Mirrors `_read_dense_memmap` for the ragged layout — same purpose:
+    proves the on-disk artifact is self-describing (offsets in sidecar,
+    flat tensor in .bin) without going through any fpwap accessor.
+    """
+    from fpwap import RaggedTensor
+
+    meta = json.loads(sidecar.read_text())
+    assert meta["layout"] == "ragged"
+    per_row = tuple(meta["per_row_shape"])
+    bf16_as_u16 = bool(meta.get("bf16_as_u16", False))
+    np_dtype = np.uint16 if bf16_as_u16 else np.dtype(meta["dtype"])
+    offsets = torch.tensor(meta["offsets"], dtype=torch.int64)
+    total = int(offsets[-1].item())
+    mm = np.memmap(path, dtype=np_dtype, mode="r", shape=(total, *per_row))
+    flat = torch.from_numpy(np.asarray(mm))
+    if bf16_as_u16:
+        flat = flat.view(torch.bfloat16)
+    return RaggedTensor(flat=flat, offsets=offsets)
+
+
 @pytest.mark.integration
 def test_as_path_dense_inplace(tmp_path: Path) -> None:
     """as_path=True returns a ResultArtifact pointing at the backend's
@@ -233,6 +256,12 @@ def test_as_path_ragged_inplace(tmp_path: Path) -> None:
     assert isinstance(rt, RaggedTensor)
     assert int(rt.offsets[-1].item()) == sum(keep)
 
+    # Self-describing: third party reconstructs the same RaggedTensor
+    # from (data_path, sidecar_path) alone — symmetric with the dense test.
+    via_path = _read_ragged_memmap(art.data_path, art.sidecar_path)
+    assert torch.equal(via_path.flat, rt.flat)
+    assert torch.equal(via_path.offsets, rt.offsets)
+
 
 @pytest.mark.integration
 def test_as_path_ragged_hardlink_to_dest(tmp_path: Path) -> None:
@@ -266,6 +295,61 @@ def test_as_path_ragged_hardlink_to_dest(tmp_path: Path) -> None:
     meta = json.loads(art.sidecar_path.read_text())
     assert meta["layout"] == "ragged"
     assert meta["offsets"][-1] == sum(keep)
+
+    # Self-describing round-trip via the dest paths matches the live
+    # ragged accessor — same coverage the dense-dest test gives.
+    from fpwap import RaggedTensor
+
+    rt = result.activations(layer=1, hook="residual_post")
+    assert isinstance(rt, RaggedTensor)
+    via_path = _read_ragged_memmap(art.data_path, art.sidecar_path)
+    assert torch.equal(via_path.flat, rt.flat)
+    assert torch.equal(via_path.offsets, rt.offsets)
+
+
+@pytest.mark.integration
+def test_as_path_dest_collision_raises(tmp_path: Path) -> None:
+    """Two `path_for(dest=same_dir)` calls for the same shard collide on
+    the destination filename. We surface that with FileExistsError instead
+    of silently clobbering a previous handle the caller may still hold."""
+    from fpwap import Sweep
+    from fpwap.callbacks.common import RawActivations
+    from fpwap.storage.memmap import MemmapBackend
+
+    model = _tiny_gpt2()
+    backend_root = tmp_path / "backend"
+    dest = tmp_path / "user_dest"
+    dest.mkdir()
+    backend = MemmapBackend(root=backend_root)
+    result = Sweep(
+        model=model,
+        dataset=_dataset(),
+        seq_len=SEQ_LEN,
+        callbacks=[
+            RawActivations(layers="all", last_token_only=False, out_dtype=torch.float32)
+        ],
+        transport_dtype=torch.float32,
+        microbatch_size=2,
+        seed=SEED,
+        progress=False,
+        storage=backend,
+    ).run()
+
+    result.activations(layer=0, hook="residual_post", as_path=dest)
+    with pytest.raises(FileExistsError):
+        result.activations(layer=0, hook="residual_post", as_path=dest)
+
+
+@pytest.mark.parametrize("empty", ["", Path("")])
+def test_as_path_empty_raises(empty) -> None:
+    """as_path='' is falsy and would silently fall through to the in-memory
+    branch; as_path=Path('') is truthy and resolves to cwd → hardlinks
+    silently into the working dir. Both are config bugs — fail loud."""
+    from fpwap.engine import Result
+
+    res = Result(sweep_id="x")
+    with pytest.raises(ValueError, match="non-empty"):
+        res.activations(layer=0, hook="residual_post", as_path=empty)
 
 
 def test_as_path_without_storage_raises() -> None:

--- a/tests/unit/test_result_artifact.py
+++ b/tests/unit/test_result_artifact.py
@@ -1,0 +1,68 @@
+"""ResultArtifact dataclass shape — CI-safe (no GPU, no model).
+
+Issue #70 introduces a small handle returned by `Result.activations(..., as_path=True)`
+that bundles the data path with sidecar/dtype/shape metadata so callers can
+mmap-read on demand instead of materializing a host-RAM tensor.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def test_result_artifact_dense_fields(tmp_path: Path) -> None:
+    from fpwap import ResultArtifact
+
+    data = tmp_path / "layer_0001_residual_post.bin"
+    sidecar = tmp_path / "layer_0001_residual_post.json"
+    data.touch()
+    sidecar.touch()
+
+    art = ResultArtifact(
+        data_path=data,
+        sidecar_path=sidecar,
+        layout="dense",
+        dtype=torch.bfloat16,
+        shape=(10_000, 128, 8192),
+    )
+    assert art.data_path == data
+    assert art.sidecar_path == sidecar
+    assert art.layout == "dense"
+    assert art.dtype == torch.bfloat16
+    assert art.shape == (10_000, 128, 8192)
+
+
+def test_result_artifact_ragged_shape_is_none(tmp_path: Path) -> None:
+    """Ragged emits don't have a uniform [N, ...] shape — sample lengths
+    differ. The sidecar JSON carries per-sample offsets; `shape` is None
+    so callers know to use the sidecar / `RaggedTensor.lengths`."""
+    from fpwap import ResultArtifact
+
+    art = ResultArtifact(
+        data_path=tmp_path / "x.bin",
+        sidecar_path=tmp_path / "x.json",
+        layout="ragged",
+        dtype=torch.float32,
+        shape=None,
+    )
+    assert art.layout == "ragged"
+    assert art.shape is None
+
+
+def test_result_artifact_is_frozen(tmp_path: Path) -> None:
+    """Frozen so callers can use it as a stable handle / dict key."""
+    from dataclasses import FrozenInstanceError
+
+    from fpwap import ResultArtifact
+
+    art = ResultArtifact(
+        data_path=tmp_path / "x.bin",
+        sidecar_path=None,
+        layout="dense",
+        dtype=torch.float32,
+        shape=(1, 1),
+    )
+    with pytest.raises(FrozenInstanceError):
+        art.data_path = tmp_path / "y.bin"  # type: ignore[misc]


### PR DESCRIPTION
Closes #70.

## Summary
- New `ResultArtifact` (frozen dataclass): `data_path`, `sidecar_path`, `layout`, `dtype`, `shape` (None for ragged).
- `Result.activations(layer, hook, as_path=...)` — `False` (default) returns the existing `Tensor | RaggedTensor`; `True` returns an in-place `ResultArtifact` pointing at the backend's file; a `Path`/`str` hardlinks the data + sidecar into that dir (copy fallback on EXDEV) and points the artifact there. Raises if no `StorageBackend` is wired.
- `StorageBackend.path_for(layer_idx, hook, dest=None)` added to the protocol; implemented on `MemmapBackend`. Drains the shard and finalizes ragged shards (writes the offsets sidecar) so the on-disk artifact is self-describing.
- Backend keeps ownership of the original file in dest mode — `as_path` does not transfer ownership, so `#67` auto-cleanup, `#68` per-sweep namespacing, and existing `read_all` semantics are untouched.

## Why API A and not `save_to`
`activations()` is already a thin dispatcher to `storage.read_all`, and `MemmapBackend` already names files predictably (`layer_{i:04d}_{hook}.bin` + `.json` sidecar). A path-handle return is purely additive: one kwarg branch, one new protocol method, one new dataclass — no ownership-transfer state machine, no idempotency loss, no collision with cleanup work in flight.

## Test plan
- [x] `tests/unit/test_result_artifact.py` — dataclass shape, frozen, dense vs ragged
- [x] `tests/integration/test_activations_as_path.py` — dense in-place, dense hardlink-to-dest (verifies same-inode), ragged in-place (sidecar offsets), ragged hardlink-to-dest, no-backend error
- [x] Self-describing: `_read_dense_memmap` reconstructs the tensor from `(data_path, sidecar_path)` alone and matches `result.activations(...)`
- [x] Regression on `test_memmap_backend.py`, `test_engine_ragged_emit.py`, `test_raw_activations.py`, `test_readme_workflow.py` — green
- [x] Full `not gpu` suite: 273 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)