### PR TITLE
Resolve module params through transformers 5.x checkpoint conversion (#77)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,11 @@
 name: release
 
-# Tag and create a GitHub release whenever main lands with a pyproject
-# version that has no tag yet. Releasing = bumping `version` in
-# pyproject.toml; merges that don't bump are no-ops here.
+# Tag, create a GitHub release, and publish to PyPI whenever main lands
+# with a pyproject version that has no tag yet. Releasing = bumping
+# `version` in pyproject.toml; merges that don't bump are no-ops here.
+#
+# PyPI auth is trusted publishing (OIDC) — registered on pypi.org for
+# this repo + workflow + the `pypi` environment. No tokens.
 
 on:
   push:
@@ -14,6 +17,9 @@ permissions:
 jobs:
   tag-release:
     runs-on: ubuntu-latest
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,16 +29,38 @@ jobs:
           echo "version=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)" >> "$GITHUB_OUTPUT"
 
       - name: Create release if tag missing
+        id: release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="v${{ steps.version.outputs.version }}"
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "release $tag already exists — skipping"
+            echo "released=false" >> "$GITHUB_OUTPUT"
           else
             gh release create "$tag" \
               --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" \
               --title "fpwap $tag" \
               --generate-notes
+            echo "released=true" >> "$GITHUB_OUTPUT"
           fi
+
+  publish-pypi:
+    needs: tag-release
+    if: needs.tag-release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+# Tag and create a GitHub release whenever main lands with a pyproject
+# version that has no tag yet. Releasing = bumping `version` in
+# pyproject.toml; merges that don't bump are no-ops here.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version
+        id: version
+        run: |
+          echo "version=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)" >> "$GITHUB_OUTPUT"
+
+      - name: Create release if tag missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${{ steps.version.outputs.version }}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release $tag already exists — skipping"
+          else
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title "fpwap $tag" \
+              --generate-notes
+          fi

--- a/SPEC.md
+++ b/SPEC.md
@@ -680,3 +680,11 @@ The residual buffer is populated by running the embedding layer over the whole d
 ### D.6 Attention mask shape assumptions
 
 Some HF model implementations expect a 2D `attention_mask`; others broadcast a 4D causal mask internally. When you call `model.layers[i](x)` directly (bypassing the top-level forward), you may have to construct the mask yourself in the shape the layer expects. Model-family-specific; document per family in `fpwap.models.*`.
+
+### D.7 Checkpoint layout ≠ module layout under transformers ≥ 5
+
+The keys in the safetensors shards are not always the module parameter names. transformers ≥ 5 reconciles them through a global `WeightConverter` mapping inside `from_pretrained` — e.g. every current HF MoE checkpoint stores per-expert `mlp.experts.E.{gate_proj,up_proj,down_proj}.weight`, while the instantiated module holds fused stacked `mlp.experts.{gate_up_proj,down_proj}`. An index built from raw shard keys is missing those module params, and the set grows silently as transformers registers more conversions.
+
+fpwap resolves module params through the same mapping at index-build time (`build_conversion_plans`) and fuses the source tensors on demand at load time (`ConvertingWeightsLoader`), preserving the natural-sort collection order `from_pretrained` uses — expert stacking order depends on it. Per-layer fusion cost is small relative to NVMe read time.
+
+Symptom: `KeyError: 'model.layers.0.mlp.experts.gate_up_proj'` in `_load_layer`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fpwap"
-version = "0.0.0"
+version = "0.1.0"
 description = "Forward Pass Weight Amortization Protocol — invert the inference loop for large transformer models."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -480,14 +480,34 @@ class _OffloadStreamer(_LayerStreamer):
 
     execution_device: torch.device  # non-None; overrides base's Optional
 
-    def __init__(self, accel_index: dict[str, Any], execution_device: torch.device) -> None:
+    def __init__(
+        self,
+        accel_index: dict[str, Any],
+        execution_device: torch.device,
+        model: nn.Module | None = None,
+    ) -> None:
         from accelerate.utils import OffloadedWeightsLoader
 
+        from fpwap.loader import ConvertingWeightsLoader, build_conversion_plans
+
         self.execution_device = execution_device
-        self._loader = OffloadedWeightsLoader(index=accel_index)
+        # Plans must be built before the loader: transformers' checkpoint
+        # conversions can alias renamed keys into accel_index, and
+        # OffloadedWeightsLoader caches the index at construction (SPEC D.3).
+        plans = build_conversion_plans(model, accel_index) if model is not None else {}
+        loader: Any = OffloadedWeightsLoader(index=accel_index)
+        if plans:
+            loader = ConvertingWeightsLoader(
+                loader, plans, config=getattr(model, "config", None)
+            )
+        self._loader = loader
         self._accel_index = accel_index
         self.last_load_bytes = 0
-        self._advisor = ShardPageAdvisor(accel_index)
+        virtual_sources = {
+            target: [key for key, _ in plan.sources]
+            for target, plan in plans.items()
+        }
+        self._advisor = ShardPageAdvisor(accel_index, virtual_sources=virtual_sources)
         # Single-worker pool: next layer's load runs on a worker thread so
         # safetensors read + H2D overlap with the main thread's compute on
         # the current layer. Modern GPUs have a separate copy engine, so
@@ -1060,7 +1080,13 @@ class Sweep:
                         "execution_device is required when using a pre-built accel_index "
                         "(Extractor path)"
                     )
-                return self.model, _OffloadStreamer(self._accel_index, self.execution_device), None
+                return (
+                    self.model,
+                    _OffloadStreamer(
+                        self._accel_index, self.execution_device, model=self.model
+                    ),
+                    None,
+                )
             return self.model, _PreloadedStreamer(self.execution_device), None
         if isinstance(self.model, str):
             if self.execution_device is None:
@@ -1088,7 +1114,9 @@ class Sweep:
                 index_s=build_timing["index_s"],
                 total_s=resolve_s + sum(build_timing.values()),
             )
-            streamer = _OffloadStreamer(accel_index, self.execution_device)
+            streamer = _OffloadStreamer(
+                accel_index, self.execution_device, model=model
+            )
             return model, streamer, setup
         got = type(self.model).__name__
         raise TypeError(

--- a/src/fpwap/loader.py
+++ b/src/fpwap/loader.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import copy
 import json
 import os
 import struct
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import torch
 from huggingface_hub import snapshot_download
@@ -126,6 +128,166 @@ def alias_tied_weights_in_index(
             source_entry = accel_index[sources[0]]
             for t in targets:
                 accel_index[t] = source_entry
+
+
+@dataclass
+class WeightConversionPlan:
+    """Recipe to realize one converted module param from raw checkpoint keys.
+
+    `converter` is the transformers WeightTransform that owns the conversion
+    (e.g. MergeModulelist + Concatenate for fused MoE experts). It is a
+    template: transformers' transforms accumulate per-load state, so every
+    materialization deep-copies it first. `sources` preserves the natural-sort
+    order `from_pretrained` collects tensors in — expert stacking order
+    depends on it. `targets` lists every full module-param name the convert
+    realizes (one-to-many converters like qkv-split produce several).
+    """
+
+    converter: Any
+    sources: list[tuple[str, str]] = field(default_factory=list)
+    targets: list[str] = field(default_factory=list)
+
+
+def build_conversion_plans(
+    model: nn.Module,
+    accel_index: dict[str, dict[str, Any]],
+) -> dict[str, WeightConversionPlan]:
+    """Map module param names to conversion plans over raw checkpoint keys.
+
+    transformers ≥5 reconciles checkpoints whose on-disk layout differs from
+    the instantiated modules (all current HF MoE checkpoints: per-expert
+    tensors on disk, fused stacked params in the module) through a global
+    WeightConverter mapping applied inside `from_pretrained`. fpwap's index
+    is built from raw safetensors keys, so module params produced by such a
+    conversion are missing from it — resolve them here so the streaming
+    loader can fuse on demand (issue #77).
+
+    Returns {} when the installed transformers has no conversion machinery
+    (<5.x — layouts match by construction there) or when every module param
+    resolves directly against the index. Keys are full module-param names;
+    plans for one-to-many converters are shared across their targets.
+    """
+    try:
+        from transformers.conversion_mapping import get_model_conversion_mapping
+        from transformers.core_model_loading import (
+            WeightConverter,
+            WeightRenaming,
+            dot_natural_key,
+            rename_source_key,
+        )
+    except ImportError:
+        return {}
+
+    # Annotated for PreTrainedModel upstream, but only walks named_modules —
+    # safe for any nn.Module (non-HF modules just get the legacy renames).
+    weight_mapping = get_model_conversion_mapping(cast(Any, model))
+    renamings = [m for m in weight_mapping if isinstance(m, WeightRenaming)]
+    converters = [m for m in weight_mapping if isinstance(m, WeightConverter)]
+    if not renamings and not converters:
+        return {}
+
+    meta_state_dict = model.state_dict()
+    prefix = getattr(model, "base_model_prefix", None)
+    pattern_to_converter = {
+        pattern: converter
+        for converter in converters
+        for pattern in converter.source_patterns
+    }
+
+    grouped: dict[str, WeightConversionPlan] = {}
+    for original_key in sorted(accel_index, key=dot_natural_key):
+        renamed_key, source_pattern = rename_source_key(
+            original_key, renamings, converters, prefix, meta_state_dict
+        )
+        if renamed_key not in meta_state_dict and original_key in meta_state_dict:
+            # Mirrors from_pretrained: the key matched a pattern but the
+            # renamed form doesn't exist — it shouldn't have been renamed.
+            renamed_key, source_pattern = rename_source_key(
+                original_key, [], [], prefix, meta_state_dict
+            )
+        if renamed_key not in meta_state_dict:
+            continue
+        if source_pattern is None:
+            if renamed_key != original_key and renamed_key not in accel_index:
+                # Pure renaming (legacy keys, prefix moves): same bytes under
+                # a new name — alias the index entry like tied weights.
+                accel_index[renamed_key] = accel_index[original_key]
+            continue
+        converter = pattern_to_converter[source_pattern]
+        plan = grouped.setdefault(renamed_key, WeightConversionPlan(converter))
+        plan.sources.append((original_key, source_pattern))
+
+    plans: dict[str, WeightConversionPlan] = {}
+    for first_target, plan in grouped.items():
+        # One-to-many converters realize every target in one convert() call;
+        # expose the plan under each full target name (transformers derives
+        # them the same way for its unexpected-keys accounting).
+        target_patterns = plan.converter.target_patterns
+        plan.targets = [
+            first_target.replace(target_patterns[0], pattern)
+            for pattern in target_patterns
+        ]
+        for target in plan.targets:
+            plans[target] = plan
+    return plans
+
+
+class ConvertingWeightsLoader:
+    """Dict-like loader that resolves converted module params on demand.
+
+    Raw checkpoint keys pass straight through to the wrapped
+    OffloadedWeightsLoader; module param names that only exist after
+    transformers' checkpoint conversion (fused MoE experts, split qkv, ...)
+    are materialized by loading their source tensors and running the
+    registered conversion, exactly as `from_pretrained` would. Sibling
+    outputs of one-to-many converts are cached until first read so each
+    source tensor is read from disk once.
+    """
+
+    def __init__(
+        self,
+        base: Any,
+        plans: dict[str, WeightConversionPlan],
+        config: Any = None,
+    ) -> None:
+        self._base = base
+        self._plans = plans
+        self._config = config
+        self._realized: dict[str, torch.Tensor] = {}
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._base or key in self._plans
+
+    def keys(self) -> list[str]:
+        return list(self._base.keys()) + list(self._plans.keys())
+
+    def __getitem__(self, key: str) -> torch.Tensor:
+        if key in self._base:
+            return self._base[key]  # type: ignore[no-any-return]
+        if key in self._realized:
+            return self._realized.pop(key)
+        plan = self._plans.get(key)
+        if plan is None:
+            raise KeyError(
+                f"{key!r} is neither a checkpoint weight nor a converted "
+                f"module param — the snapshot may not match the instantiated "
+                f"model under the installed transformers version"
+            )
+        converter = copy.deepcopy(plan.converter)
+        first_target = plan.targets[0]
+        for source_key, source_pattern in plan.sources:
+            # Callables → transformers' sync materialization path; the read
+            # from disk happens inside convert(), one source at a time.
+            converter.add_tensor(
+                first_target,
+                source_key,
+                source_pattern,
+                lambda source_key=source_key: self._base[source_key],
+            )
+        realized = converter.convert(first_target, config=self._config)
+        for name, value in realized.items():
+            self._realized[name] = value[0] if isinstance(value, list) else value
+        return self._realized.pop(key)
 
 
 def build_empty_model_and_index(
@@ -302,10 +464,20 @@ class ShardPageAdvisor:
     Uses posix_fadvise(DONTNEED) after a layer is unloaded so the kernel
     can reclaim those pages for upcoming layers. On non-Linux platforms
     (no posix_fadvise), all methods are silent no-ops.
+
+    `virtual_sources` maps module param names that don't exist on disk
+    (converted weights, e.g. fused MoE experts) to the raw checkpoint keys
+    backing them, so advising on the module name reaches the real byte
+    ranges.
     """
 
-    def __init__(self, accel_index: dict[str, dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        accel_index: dict[str, dict[str, Any]],
+        virtual_sources: dict[str, list[str]] | None = None,
+    ) -> None:
         self._offsets: dict[str, tuple[str, int, int]] = {}
+        self._virtual_sources = virtual_sources or {}
         if not _HAS_POSIX_FADVISE:
             return
 
@@ -328,7 +500,10 @@ class ShardPageAdvisor:
         if not _HAS_POSIX_FADVISE:
             return
         by_shard: dict[str, list[tuple[int, int]]] = {}
+        expanded: list[str] = []
         for name in weight_names:
+            expanded.extend(self._virtual_sources.get(name, (name,)))
+        for name in expanded:
             if name not in self._offsets:
                 continue
             path, start, end = self._offsets[name]

--- a/src/fpwap/models/llama.py
+++ b/src/fpwap/models/llama.py
@@ -124,6 +124,10 @@ class LlamaPlumbing:
         residual = h
         h = b.post_attention_layernorm(h)
         mlp_output = b.mlp(h)
+        if isinstance(mlp_output, tuple):
+            # MoE sparse blocks on transformers < 5.6 return
+            # (hidden_states, router_logits); the residual add needs the tensor.
+            mlp_output = mlp_output[0]
         if "mlp_out" in wanted_hooks:
             if dispatch_fn is not None:
                 mlp_output = dispatch_fn("mlp_out", mlp_output)

--- a/tests/gpu/test_moe_streaming_bit_exact.py
+++ b/tests/gpu/test_moe_streaming_bit_exact.py
@@ -120,8 +120,18 @@ def test_moe_streaming_matches_preloaded(tmp_path: Path) -> None:
             self.acts[layer_idx][sample_ids] = acts.detach()
             return None
 
-    # Run A: pre-loaded model (weights fused by from_pretrained itself).
-    preloaded = src.to("cuda:0")
+    del src
+
+    # Run A: pre-loaded model, fused by from_pretrained's own conversion.
+    # NOT the in-memory src: `.to(bf16)` on it would also cast the fp32
+    # rotary inv_freq buffer, which from_config-built streaming models keep
+    # in fp32 — a ULP-level RoPE mismatch that has nothing to do with #77.
+    from transformers import AutoModelForCausalLM
+
+    preloaded = AutoModelForCausalLM.from_pretrained(
+        snapshot_dir, dtype=torch.bfloat16
+    ).to("cuda:0")
+    preloaded.eval()
     cap_pre = Capture()
     Sweep(
         model=preloaded,
@@ -134,7 +144,7 @@ def test_moe_streaming_matches_preloaded(tmp_path: Path) -> None:
         progress=False,
     ).run()
 
-    del preloaded, src
+    del preloaded
     torch.cuda.empty_cache()
 
     # Run B: streaming from the per-expert snapshot — the #77 repro path.

--- a/tests/gpu/test_moe_streaming_bit_exact.py
+++ b/tests/gpu/test_moe_streaming_bit_exact.py
@@ -1,0 +1,161 @@
+"""Streaming-path bit-exactness on an MoE model with a converted checkpoint.
+
+Issue #77: HF MoE checkpoints store per-expert weights on disk while the
+transformers 5.x modules hold fused stacked parameters. The streaming loader
+must apply the same checkpoint conversion `from_pretrained` does, then the
+loop must produce activations identical to the pre-loaded model.
+
+Uses a tiny Qwen3-MoE built in-test and saved in the on-disk per-expert
+layout, so it runs in seconds and needs no downloads.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+SEQ_LEN = 8
+N_SAMPLES = 4
+HIDDEN = 16
+N_LAYERS = 2
+
+
+def _write_tiny_qwen3_moe_snapshot(tmp_path: Path) -> tuple[torch.nn.Module, Path]:
+    """Save a tiny Qwen3-MoE in the per-expert on-disk layout (see unit twin)."""
+    from transformers.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
+
+    config = Qwen3MoeConfig(
+        vocab_size=64,
+        hidden_size=HIDDEN,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_hidden_layers=N_LAYERS,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_experts=4,
+        num_experts_per_tok=2,
+        head_dim=8,
+        decoder_sparse_step=1,
+        mlp_only_layers=[],
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    src = Qwen3MoeForCausalLM(config).to(torch.bfloat16)
+    src.eval()
+
+    m = config.moe_intermediate_size
+    shard: dict[str, torch.Tensor] = {}
+    for name, value in src.state_dict().items():
+        if name.endswith("mlp.experts.gate_up_proj"):
+            base = name.rsplit(".gate_up_proj", 1)[0]
+            for e in range(config.num_experts):
+                shard[f"{base}.{e}.gate_proj.weight"] = value[e, :m, :].contiguous()
+                shard[f"{base}.{e}.up_proj.weight"] = value[e, m:, :].contiguous()
+        elif name.endswith("mlp.experts.down_proj"):
+            base = name.rsplit(".down_proj", 1)[0]
+            for e in range(config.num_experts):
+                shard[f"{base}.{e}.down_proj.weight"] = value[e].contiguous()
+        else:
+            shard[name] = value.contiguous()
+
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    save_file(shard, snapshot_dir / "model.safetensors")
+    hf_index = {
+        "metadata": {"total_size": 0},
+        "weight_map": {k: "model.safetensors" for k in shard},
+    }
+    (snapshot_dir / "model.safetensors.index.json").write_text(json.dumps(hf_index))
+    config.save_pretrained(snapshot_dir)
+    return src, snapshot_dir
+
+
+@pytest.mark.gpu
+def test_moe_streaming_matches_preloaded(tmp_path: Path) -> None:
+    pytest.importorskip("transformers.conversion_mapping")
+
+    from fpwap import Callback, Sweep
+    from fpwap.types import BatchResult, HookName
+
+    src, snapshot_dir = _write_tiny_qwen3_moe_snapshot(tmp_path)
+
+    torch.manual_seed(1)
+    input_ids = torch.randint(0, 64, (N_SAMPLES, SEQ_LEN), device="cuda:0")
+    attention_mask = torch.ones_like(input_ids)
+    dataset = [
+        {
+            "input_ids": input_ids[i : i + 1],
+            "attention_mask": attention_mask[i : i + 1],
+        }
+        for i in range(N_SAMPLES)
+    ]
+
+    class Capture(Callback):
+        phase = "read"
+        target_layers = "all"
+        target_hooks: tuple[HookName, ...] = ("residual_post",)
+
+        def __init__(self) -> None:
+            self.acts: dict[int, torch.Tensor] = {
+                i: torch.zeros(
+                    N_SAMPLES,
+                    SEQ_LEN,
+                    HIDDEN,
+                    dtype=torch.bfloat16,
+                    device="cuda:0",
+                )
+                for i in range(N_LAYERS)
+            }
+
+        def on_batch(
+            self,
+            layer_idx: int,
+            hook: HookName,
+            acts: torch.Tensor,
+            sample_ids: torch.Tensor,
+        ) -> BatchResult:
+            self.acts[layer_idx][sample_ids] = acts.detach()
+            return None
+
+    # Run A: pre-loaded model (weights fused by from_pretrained itself).
+    preloaded = src.to("cuda:0")
+    cap_pre = Capture()
+    Sweep(
+        model=preloaded,
+        dataset=dataset,
+        seq_len=SEQ_LEN,
+        callbacks=[cap_pre],
+        transport_dtype=torch.bfloat16,
+        microbatch_size=N_SAMPLES,
+        seed=0,
+        progress=False,
+    ).run()
+
+    del preloaded, src
+    torch.cuda.empty_cache()
+
+    # Run B: streaming from the per-expert snapshot — the #77 repro path.
+    cap_stream = Capture()
+    Sweep(
+        model=str(snapshot_dir),
+        dataset=dataset,
+        seq_len=SEQ_LEN,
+        callbacks=[cap_stream],
+        transport_dtype=torch.bfloat16,
+        microbatch_size=N_SAMPLES,
+        execution_device="cuda:0",
+        seed=0,
+        progress=False,
+    ).run()
+
+    for layer_idx in range(N_LAYERS):
+        pre = cap_pre.acts[layer_idx]
+        stm = cap_stream.acts[layer_idx]
+        max_diff = (pre.float() - stm.float()).abs().max().item()
+        assert torch.equal(pre, stm), (
+            f"preloaded vs streaming mismatch at layer {layer_idx}: "
+            f"max abs diff {max_diff}"
+        )

--- a/tests/unit/test_checkpoint_conversion.py
+++ b/tests/unit/test_checkpoint_conversion.py
@@ -1,0 +1,248 @@
+"""Contract for transformers 5.x checkpoint conversion in the loader (issue #77).
+
+HF MoE checkpoints store per-expert weights on disk
+(`...mlp.experts.E.{gate_proj,up_proj,down_proj}.weight`) while the
+instantiated transformers 5.x modules hold fused stacked parameters
+(`...mlp.experts.{gate_up_proj,down_proj}`). `from_pretrained` reconciles the
+two through the global WeightConverter mapping; fpwap builds its accel index
+from raw safetensors keys, so module param names must be resolved through the
+same conversion mapping or `_load_layer` KeyErrors on every MoE model.
+
+These tests exercise the conversion plumbing on a tiny Qwen3-MoE checkpoint
+written in the on-disk per-expert layout. CPU-only; CI-safe.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+pytest.importorskip("transformers.conversion_mapping")
+
+# TODO(#77): remove once the conversion plumbing lands.
+pytestmark = pytest.mark.xfail(
+    strict=True, reason="issue #77: checkpoint conversion not yet implemented"
+)
+
+
+def _write_tiny_qwen3_moe_snapshot(tmp_path: Path) -> tuple[torch.nn.Module, Path]:
+    """Save a tiny Qwen3-MoE in the on-disk per-expert layout.
+
+    Returns (source_model_with_real_fused_weights, snapshot_dir). The shard
+    keys deliberately mismatch the module param names — exactly the layout
+    `from_pretrained` reconciles via MergeModulelist + Concatenate.
+    """
+    from transformers.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
+
+    config = Qwen3MoeConfig(
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_experts=4,
+        num_experts_per_tok=2,
+        head_dim=8,
+        decoder_sparse_step=1,
+        mlp_only_layers=[],
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    src = Qwen3MoeForCausalLM(config)
+    src.eval()
+
+    m = config.moe_intermediate_size
+    shard: dict[str, torch.Tensor] = {}
+    for name, value in src.state_dict().items():
+        if name.endswith("mlp.experts.gate_up_proj"):
+            base = name.rsplit(".gate_up_proj", 1)[0]
+            for e in range(config.num_experts):
+                shard[f"{base}.{e}.gate_proj.weight"] = value[e, :m, :].contiguous()
+                shard[f"{base}.{e}.up_proj.weight"] = value[e, m:, :].contiguous()
+        elif name.endswith("mlp.experts.down_proj"):
+            base = name.rsplit(".down_proj", 1)[0]
+            for e in range(config.num_experts):
+                shard[f"{base}.{e}.down_proj.weight"] = value[e].contiguous()
+        else:
+            shard[name] = value.contiguous()
+
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    save_file(shard, snapshot_dir / "model.safetensors")
+    hf_index = {
+        "metadata": {"total_size": 0},
+        "weight_map": {k: "model.safetensors" for k in shard},
+    }
+    (snapshot_dir / "model.safetensors.index.json").write_text(json.dumps(hf_index))
+    config.save_pretrained(snapshot_dir)
+    return src, snapshot_dir
+
+
+def _build_empty(snapshot_dir: Path):
+    from fpwap.loader import build_empty_model_and_index
+
+    return build_empty_model_and_index(
+        model_id=str(snapshot_dir), snapshot_dir=snapshot_dir, dtype=torch.float32
+    )
+
+
+class TestBuildConversionPlans:
+    def test_plans_cover_fused_moe_params(self, tmp_path: Path) -> None:
+        from fpwap.loader import build_conversion_plans
+
+        _, snapshot_dir = _write_tiny_qwen3_moe_snapshot(tmp_path)
+        model, accel_index, _ = _build_empty(snapshot_dir)
+        plans = build_conversion_plans(model, accel_index)
+
+        for layer in range(2):
+            for fused in ("gate_up_proj", "down_proj"):
+                name = f"model.layers.{layer}.mlp.experts.{fused}"
+                assert name in plans, f"no conversion plan for {name}"
+                assert name not in accel_index
+
+    def test_plan_sources_are_raw_checkpoint_keys_in_expert_order(
+        self, tmp_path: Path
+    ) -> None:
+        from fpwap.loader import build_conversion_plans
+
+        _, snapshot_dir = _write_tiny_qwen3_moe_snapshot(tmp_path)
+        model, accel_index, _ = _build_empty(snapshot_dir)
+        plans = build_conversion_plans(model, accel_index)
+
+        plan = plans["model.layers.0.mlp.experts.down_proj"]
+        source_keys = [key for key, _pattern in plan.sources]
+        assert source_keys == [
+            f"model.layers.0.mlp.experts.{e}.down_proj.weight" for e in range(4)
+        ]
+        for key in source_keys:
+            assert key in accel_index
+
+    def test_no_plans_for_plain_dense_model(self, tmp_path: Path) -> None:
+        """A model whose checkpoint layout matches its module layout needs no
+        conversion — the fast path must stay plan-free."""
+        from transformers import GPT2Config, GPT2LMHeadModel
+
+        from fpwap.loader import build_conversion_plans
+
+        config = GPT2Config(
+            vocab_size=40, n_positions=8, n_embd=16, n_layer=2, n_head=2
+        )
+        torch.manual_seed(0)
+        src = GPT2LMHeadModel(config)
+        state_dict = {
+            k: v.contiguous()
+            for k, v in src.state_dict().items()
+            if k != "lm_head.weight"
+        }
+        snapshot_dir = tmp_path / "snapshot"
+        snapshot_dir.mkdir()
+        save_file(state_dict, snapshot_dir / "model.safetensors")
+        hf_index = {
+            "metadata": {"total_size": 0},
+            "weight_map": {k: "model.safetensors" for k in state_dict},
+        }
+        (snapshot_dir / "model.safetensors.index.json").write_text(
+            json.dumps(hf_index)
+        )
+        config.save_pretrained(snapshot_dir)
+
+        model, accel_index, _ = _build_empty(snapshot_dir)
+        assert build_conversion_plans(model, accel_index) == {}
+
+
+class TestConvertingWeightsLoader:
+    def _make_loader(self, snapshot_dir: Path):
+        from accelerate.utils import OffloadedWeightsLoader
+
+        from fpwap.loader import ConvertingWeightsLoader, build_conversion_plans
+
+        model, accel_index, _ = _build_empty(snapshot_dir)
+        plans = build_conversion_plans(model, accel_index)
+        base = OffloadedWeightsLoader(index=accel_index)
+        return model, ConvertingWeightsLoader(base, plans, config=model.config)
+
+    def test_fuses_gate_up_and_down_on_demand(self, tmp_path: Path) -> None:
+        src, snapshot_dir = _write_tiny_qwen3_moe_snapshot(tmp_path)
+        _, loader = self._make_loader(snapshot_dir)
+
+        for layer in range(2):
+            experts = src.model.layers[layer].mlp.experts
+            fused_gate_up = loader[f"model.layers.{layer}.mlp.experts.gate_up_proj"]
+            fused_down = loader[f"model.layers.{layer}.mlp.experts.down_proj"]
+            assert torch.equal(fused_gate_up, experts.gate_up_proj.data)
+            assert torch.equal(fused_down, experts.down_proj.data)
+
+    def test_raw_keys_pass_through(self, tmp_path: Path) -> None:
+        src, snapshot_dir = _write_tiny_qwen3_moe_snapshot(tmp_path)
+        _, loader = self._make_loader(snapshot_dir)
+
+        embed = loader["model.embed_tokens.weight"]
+        assert torch.equal(embed, src.model.embed_tokens.weight.data)
+
+    def test_unknown_key_raises_keyerror(self, tmp_path: Path) -> None:
+        _, snapshot_dir = _write_tiny_qwen3_moe_snapshot(tmp_path)
+        _, loader = self._make_loader(snapshot_dir)
+
+        with pytest.raises(KeyError):
+            loader["model.layers.0.mlp.experts.nonexistent"]
+
+
+class TestLoadLayerWithConversion:
+    def test_load_layer_materializes_moe_layer(self, tmp_path: Path) -> None:
+        """The issue-#77 repro: _load_layer over an MoE block must resolve the
+        fused module param names instead of KeyError'ing on them."""
+        from fpwap.engine import _OffloadStreamer
+        from fpwap.models import get_plumbing
+
+        src, snapshot_dir = _write_tiny_qwen3_moe_snapshot(tmp_path)
+        model, accel_index, _ = _build_empty(snapshot_dir)
+        streamer = _OffloadStreamer(
+            accel_index, torch.device("cpu"), model=model
+        )
+        try:
+            plumbing = get_plumbing(model)
+            streamer.load_layer(model, 0, plumbing)
+
+            src_layer = src.model.layers[0]
+            dst_layer = model.model.layers[0]
+            for (src_name, src_p), (dst_name, dst_p) in zip(
+                src_layer.named_parameters(),
+                dst_layer.named_parameters(),
+                strict=True,
+            ):
+                assert src_name == dst_name
+                assert dst_p.device.type != "meta", f"{dst_name} still on meta"
+                assert torch.equal(src_p, dst_p), f"value mismatch at {dst_name}"
+        finally:
+            streamer.close()
+
+
+class TestAdvisorVirtualSources:
+    def test_fused_name_advises_source_ranges(self, tmp_path: Path) -> None:
+        """fadvise on a fused module param name must hit the underlying
+        per-expert checkpoint ranges, or MoE sweeps silently lose page-cache
+        discipline (the #61/#69 regime)."""
+        from unittest.mock import patch
+
+        from fpwap.loader import ShardPageAdvisor
+
+        _, snapshot_dir = _write_tiny_qwen3_moe_snapshot(tmp_path)
+        from fpwap.loader import build_accel_index_from_hf_cache
+
+        accel_index = build_accel_index_from_hf_cache(snapshot_dir)
+        sources = [
+            f"model.layers.0.mlp.experts.{e}.down_proj.weight" for e in range(4)
+        ]
+        advisor = ShardPageAdvisor(
+            accel_index,
+            virtual_sources={"model.layers.0.mlp.experts.down_proj": sources},
+        )
+
+        with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
+            advisor.advise_dontneed(["model.layers.0.mlp.experts.down_proj"])
+        assert mock_fadvise.call_count == 4

--- a/tests/unit/test_checkpoint_conversion.py
+++ b/tests/unit/test_checkpoint_conversion.py
@@ -22,11 +22,6 @@ from safetensors.torch import save_file
 
 pytest.importorskip("transformers.conversion_mapping")
 
-# TODO(#77): remove once the conversion plumbing lands.
-pytestmark = pytest.mark.xfail(
-    strict=True, reason="issue #77: checkpoint conversion not yet implemented"
-)
-
 
 def _write_tiny_qwen3_moe_snapshot(tmp_path: Path) -> tuple[torch.nn.Module, Path]:
     """Save a tiny Qwen3-MoE in the on-disk per-expert layout.

--- a/tests/unit/test_plumbing_moe_mlp_tuple.py
+++ b/tests/unit/test_plumbing_moe_mlp_tuple.py
@@ -1,0 +1,77 @@
+"""Decomposed-path guard for MoE sparse blocks whose mlp returns a tuple.
+
+On transformers < 5.6 the MoE sparse block returned
+`(hidden_states, router_logits)`; 5.6 returns a plain tensor. The decomposed
+`mlp_out` path in LlamaPlumbing does `residual + b.mlp(h)`, which breaks on
+the tuple form. The plumbing must unwrap before the residual add so the
+decomposed path is version-robust (issue #77, related item).
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import Tensor, nn
+
+from fpwap.models.llama import LlamaPlumbing
+
+# TODO(#77): remove once the tuple-unwrap guard lands.
+pytestmark = pytest.mark.xfail(
+    strict=True, reason="issue #77: decomposed path lacks MoE tuple unwrap"
+)
+
+HIDDEN = 8
+
+
+class _TupleMlp(nn.Module):
+    """Mimics a pre-5.6 MoE sparse block: returns (hidden, router_logits)."""
+
+    def forward(self, h: Tensor) -> tuple[Tensor, Tensor]:
+        return h * 2.0, torch.zeros(h.shape[0], 4)
+
+
+class _Attn(nn.Module):
+    def forward(self, hidden_states: Tensor, **kwargs: object) -> tuple[Tensor, None]:
+        return hidden_states * 0.5, None
+
+
+class _Block(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_layernorm = nn.Identity()
+        self.post_attention_layernorm = nn.Identity()
+        self.self_attn = _Attn()
+        self.mlp = _TupleMlp()
+
+
+class _Inner(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_Block()])
+        self.embed_tokens = nn.Embedding(4, HIDDEN)
+        self.rotary_emb = lambda hidden_states, position_ids: (None, None)
+
+
+class _Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = _Inner()
+
+
+def test_decomposed_mlp_out_unwraps_tuple_returns() -> None:
+    model = _Model()
+    plumbing = LlamaPlumbing()
+    block = model.model.layers[0]
+    hidden = torch.randn(2, 3, HIDDEN)
+
+    out, extras = plumbing.layer_forward_with_hooks(
+        model,
+        block,
+        hidden,
+        wanted_hooks=frozenset({"mlp_out"}),
+    )
+
+    # attn: h + 0.5h = 1.5h; mlp: 1.5h + 2*(1.5h) = 4.5h
+    assert isinstance(out, Tensor)
+    assert torch.allclose(out, hidden * 4.5)
+    assert isinstance(extras["mlp_out"], Tensor)
+    assert torch.allclose(extras["mlp_out"], hidden * 3.0)

--- a/tests/unit/test_plumbing_moe_mlp_tuple.py
+++ b/tests/unit/test_plumbing_moe_mlp_tuple.py
@@ -8,16 +8,10 @@ decomposed path is version-robust (issue #77, related item).
 """
 from __future__ import annotations
 
-import pytest
 import torch
 from torch import Tensor, nn
 
 from fpwap.models.llama import LlamaPlumbing
-
-# TODO(#77): remove once the tuple-unwrap guard lands.
-pytestmark = pytest.mark.xfail(
-    strict=True, reason="issue #77: decomposed path lacks MoE tuple unwrap"
-)
 
 HIDDEN = 8
 


### PR DESCRIPTION
Fixes #77.

## Problem

fpwap builds its accelerate index from raw safetensors keys, but `_load_layer` looks up **module param** names. transformers ≥5 reconciles checkpoints whose on-disk layout differs from the instantiated modules through a global `WeightConverter` mapping inside `from_pretrained` — which fpwap bypassed entirely. Every current HF MoE checkpoint (per-expert `mlp.experts.E.{gate,up,down}_proj.weight` on disk, fused stacked `mlp.experts.{gate_up_proj,down_proj}` in the module) failed at the first layer load:

```
KeyError: 'model.layers.0.mlp.experts.gate_up_proj'
```

## Fix

- **`loader.build_conversion_plans(model, accel_index)`** — resolves each raw checkpoint key through the model's registered conversion mapping (`get_model_conversion_mapping` + `rename_source_key`, the same machinery `from_pretrained` uses), grouping converted keys under their target module-param name. Collection preserves `dot_natural_key` order — expert stacking order depends on it. Pure renamings (legacy keys, prefix moves) are aliased into the index the way tied weights already are. Returns `{}` on transformers <5 (no conversion module, layouts match by construction) and for dense models, so the existing fast path is untouched.
- **`loader.ConvertingWeightsLoader`** — dict-like wrapper over `OffloadedWeightsLoader`: raw keys pass through; converted params are fused on demand by deep-copying the converter template, feeding it sync-materialization callables, and running `convert()` exactly as `from_pretrained` would. Sibling outputs of one-to-many converters (qkv-style splits) are cached until first read.
- **`_OffloadStreamer`** now takes the meta model, builds plans before constructing the loader (plans may alias renamed keys into the index, and the loader caches the index at construction — SPEC D.3), and wraps the loader only when plans exist. Both engine call sites (string-ID and Extractor reuse) pass the model.
- **`ShardPageAdvisor`** gains `virtual_sources` so `posix_fadvise` on a fused module-param name reaches the underlying per-expert byte ranges — without this, MoE sweeps silently lose page-cache discipline (~1.2 GB/layer on 30B-A3B, the #61/#69 regime).
- **Related minor item from the issue**: `LlamaPlumbing`'s decomposed `mlp_out` path now unwraps tuple returns from MoE sparse blocks (transformers <5.6 returned `(hidden_states, router_logits)`).
- SPEC Appendix D gains gotcha **D.7** documenting the conversion cliff.

## Verification

TDD per project convention: all contracts landed as strict-xfail first (commit 1, `9 xfailed`), implementation flipped them green (commit 2).

- **Approach validated empirically before implementation**: a spike confirmed `from_pretrained` fuses a per-expert tiny Qwen3-MoE snapshot, and that driving the conversion machinery with sync callables reproduces the fused tensors bit-exactly.
- **New unit tests (CI-safe, CPU)**: plan coverage of fused MoE params, expert-order source collection, dense models producing zero plans, on-demand fusion bit-equality, raw-key passthrough, actionable `KeyError`, the `_load_layer` repro through `_OffloadStreamer`, advisor virtual sources, and the decomposed-path tuple unwrap.
- **New GPU test** (`tests/gpu/test_moe_streaming_bit_exact.py`): tiny Qwen3-MoE saved in the on-disk per-expert layout, streamed via the #77 repro path, **bit-exact at every layer** against the `from_pretrained`-loaded model. (First run surfaced a ULP-level RoPE mismatch — caused by the test's own baseline `.to(bf16)` casting the fp32 `inv_freq` buffer, not by the conversion; baseline now loads via `from_pretrained(dtype=bf16)` like the existing llama twin.)
- **Full local suites green**: 199 CI-safe unit tests, 100 GPU+integration tests (8 pre-existing opt-in/cache skips), `ruff`, `mypy`.

## Out of scope

`load_from_cache` (the accelerate `disk_offload` escape hatch) still writes a raw-key `index.json`; converted params can't be represented in accelerate's one-tensor-per-name offload index, so MoE under that path would need eager fusion to an offload dir — left for a follow-up if anyone hits it. The fpwap loop itself, including the Extractor path, is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)