### PR TITLE
Run right-padded microbatches at real length — bit-exact vs solo sweeps (releases 0.1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fpwap"
-version = "0.1.0"
+version = "0.1.1"
 description = "Forward Pass Weight Amortization Protocol — invert the inference loop for large transformer models."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -675,6 +675,15 @@ def _trim_to_length(item: dict[str, Any], target_len: int, left_padded: bool) ->
     return result
 
 
+def _pad_rows(t: Tensor, target_len: int) -> Tensor:
+    """Zero-pad dim 1 (sequence) up to ``target_len`` (no-op when already there)."""
+    gap = target_len - t.shape[1]
+    if gap <= 0:
+        return t
+    z = torch.zeros((t.shape[0], gap, *t.shape[2:]), dtype=t.dtype, device=t.device)
+    return torch.cat([t, z], dim=1)
+
+
 def _build_bucketed_segments(
     items: list[Any],
     max_seq_len: int,
@@ -1509,11 +1518,36 @@ class Sweep:
 
                                 inline_dispatch = _inline
 
+                            # Right-padded microbatches run the forward at
+                            # their real max length. Pad rows are causally
+                            # inert, so trimming changes nothing semantically
+                            # — but it keeps kernel shapes identical to a
+                            # solo exact-length sweep, so with
+                            # microbatch_size=1 the real-token outputs are
+                            # bit-equal instead of drifting on
+                            # shape-dependent kernel selection (which MoE
+                            # routing amplifies into macroscopic per-token
+                            # divergence). Outputs are zero-padded back to
+                            # the bucket shape below; emit and buffer shapes
+                            # are unchanged.
+                            bucket_len = hidden_states.shape[1]
+                            fwd_len = bucket_len
+                            fwd_mask = mb_mask
+                            if mb_mask is not None:
+                                right_padded = bool(
+                                    (mb_mask[:, :-1] >= mb_mask[:, 1:]).all()
+                                )
+                                real_max = int(mb_mask.sum(dim=-1).max().item())
+                                if right_padded and 0 < real_max < bucket_len:
+                                    fwd_len = real_max
+                                    hidden_states = hidden_states[:, :real_max]
+                                    fwd_mask = mb_mask[:, :real_max]
+
                             hidden_states, extras = plumbing.layer_forward_with_hooks(
                                 model,
                                 block,
                                 hidden_states,
-                                attention_mask=mb_mask,
+                                attention_mask=fwd_mask,
                                 wanted_hooks=sub_hooks,
                                 dispatch_fn=inline_dispatch,
                             )
@@ -1521,6 +1555,12 @@ class Sweep:
 
                         if final_norm is not None and layer_idx == n_layers - 1:
                             hidden_states = final_norm(hidden_states)
+
+                        if fwd_len < bucket_len:
+                            hidden_states = _pad_rows(hidden_states, bucket_len)
+                            extras = {
+                                k: _pad_rows(v, bucket_len) for k, v in extras.items()
+                            }
 
                         t_cb = time.perf_counter_ns()
                         mb_emit_s = 0.0

--- a/src/fpwap/models/gpt2.py
+++ b/src/fpwap/models/gpt2.py
@@ -54,17 +54,25 @@ class GPT2Plumbing:
         # GPT-2's SDPA-path implementation expects a combined causal+padding 4D
         # mask (same thing GPT2Model.forward builds internally). Delegate to
         # HF's own prep helper so we match whichever attention impl is active.
+        # Right-padded inputs skip the mask entirely: under causal attention
+        # every pad key is in the future of every real query, so masking is
+        # redundant, and dropping it keeps SDPA on its fused causal path
+        # (real-token outputs match the unpadded forward bit-for-bit).
         if attention_mask is not None and attention_mask.dim() == 2:
-            from transformers.modeling_attn_mask_utils import (
-                _prepare_4d_causal_attention_mask_for_sdpa,
-            )
+            right_padded = bool((attention_mask[:, :-1] >= attention_mask[:, 1:]).all())
+            if right_padded:
+                attention_mask = None
+            else:
+                from transformers.modeling_attn_mask_utils import (
+                    _prepare_4d_causal_attention_mask_for_sdpa,
+                )
 
-            attention_mask = _prepare_4d_causal_attention_mask_for_sdpa(
-                attention_mask,
-                input_shape=(hidden_states.shape[0], hidden_states.shape[1]),
-                inputs_embeds=hidden_states,
-                past_key_values_length=0,
-            )
+                attention_mask = _prepare_4d_causal_attention_mask_for_sdpa(
+                    attention_mask,
+                    input_shape=(hidden_states.shape[0], hidden_states.shape[1]),
+                    inputs_embeds=hidden_states,
+                    past_key_values_length=0,
+                )
 
         needs_decompose = bool({"attn_out", "mlp_out"} & wanted_hooks)
         if not needs_decompose:

--- a/src/fpwap/models/llama.py
+++ b/src/fpwap/models/llama.py
@@ -75,17 +75,29 @@ class LlamaPlumbing:
         position_embeddings = rotary_emb(hidden_states, position_ids)
 
         # 2D padding mask → combined causal+padding 4D for SDPA.
+        # Exception: right-padded inputs need no mask at all under causal
+        # attention — every pad key lies in the future of every real query,
+        # so masking is redundant, and pad-row outputs are garbage either
+        # way (callers slice to real lengths). Skipping the dense 4D mask
+        # keeps SDPA on its fused causal path, so real-token outputs match
+        # the unpadded forward bit-for-bit instead of drifting on a backend
+        # switch (the HF helper already returns None for all-ones masks,
+        # which is why only padded rows ever drifted).
         if attention_mask is not None and attention_mask.dim() == 2:
-            from transformers.modeling_attn_mask_utils import (
-                _prepare_4d_causal_attention_mask_for_sdpa,
-            )
+            right_padded = bool((attention_mask[:, :-1] >= attention_mask[:, 1:]).all())
+            if right_padded:
+                ext_mask = None
+            else:
+                from transformers.modeling_attn_mask_utils import (
+                    _prepare_4d_causal_attention_mask_for_sdpa,
+                )
 
-            ext_mask = _prepare_4d_causal_attention_mask_for_sdpa(
-                attention_mask,
-                input_shape=(bsz, seq_len),
-                inputs_embeds=hidden_states,
-                past_key_values_length=0,
-            )
+                ext_mask = _prepare_4d_causal_attention_mask_for_sdpa(
+                    attention_mask,
+                    input_shape=(bsz, seq_len),
+                    inputs_embeds=hidden_states,
+                    past_key_values_length=0,
+                )
         else:
             ext_mask = None
 

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "fpwap"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "fpwap"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Problem

Bucket padding silently changes numerics. A padded forward runs every GEMM and attention kernel at the bucket shape; shape-dependent kernel selection perturbs bf16, and on sparse-MoE models router discreteness amplifies the perturbation into macroscopic per-token divergence.

Measured on Qwen3-Coder-30B-A3B (28,320 real tokens in a 32,768 bucket, microbatch 1, full depth):

- 5.6% next-token rank flips vs the solo sweep, |Δlogprob| up to 15 nats
- final-layer hidden |Δ| up to 48 at flip positions — expert-routing flips, not rounding
- an **unpadded** item (bucket == real length) in the same sweep was **bit-equal** to its solo run, isolating padding as the cause

Skipping only the dense 4D SDPA mask was insufficient (5.58% → 5.13% flips) — the bucket-shaped kernels themselves are the dominant term.

## Fix

Both changes gated on the attention mask being right-padded (every row a prefix of ones), where pad keys are causally inert:

- **engine**: trim each microbatch to its real max length for the layer forward, then zero-pad outputs back to the bucket shape so emit/buffer/storage shapes are unchanged (the memmap backend fixes `per_row_shape` from the first emit). With microbatch 1, per-sample kernel shapes are now identical to a solo sweep.
- **llama/gpt2 plumbing**: skip the dense 4D SDPA mask for right-padded rows — masking is redundant under causal attention and the dense mask pushes SDPA off its fused causal path. (The HF helper already returns `None` for all-ones masks, which is why only padded rows ever drifted.)

Left-padded inputs are untouched (they need the mask and real positions).

## Verification

- GPU forensics (downstream, `lens spikes/B/09_m3_pad_forensics.py`): padded read now **bitwise identical** to the exact read — activations and teacher-forced logprob/rank/entropy.
- Batched-vs-single equivalence over 4 units / 125,929 tokens: bitwise on all units, and **3.80× faster** than solo sweeps (1,915 vs 504 tok/s) since trimming also skips pad-row FLOPs.
- An ~11M-token production batch ran under this branch: 106 bucketed sweeps, zero incidents.
- mypy strict, ruff, 199 unit tests green.

## Release

Includes the `0.1.1` patch bump, so merging this triggers `release.yml` (tag → GitHub release → PyPI trusted publish). Downstream `lens` will then raise its floor to `fpwap>=0.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)