### PR TITLE
Staged layer loads: direct shard byte-reads + one async H2D per layer (~4.6× on MoE short-shard sweeps)

### DIFF
--- a/scripts/bench_staged_load.py
+++ b/scripts/bench_staged_load.py
@@ -1,0 +1,87 @@
+"""A/B benchmark: pinned-staged layer loads vs legacy per-tensor loads.
+
+Reproduces the lens m3 backfill symptom (load-bound MoE sweeps, flat
+~53 s regardless of token count) and measures the staged-load fix on the
+same workload shape: one unit, microbatch 1, sweep truncated at layer 41.
+
+Usage:
+    uv run scripts/bench_staged_load.py \\
+        --snapshot ~/models/qwen3-coder-30b-a3b-instruct-fp8-dequant \\
+        --seq-len 16384
+
+Runs staged → legacy → staged (interleaved to control page-cache warmth),
+prints per-layer load/forward breakdowns, and checks the captured
+activations are bitwise identical across paths.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+import torch
+
+from fpwap import Sweep
+from fpwap.callbacks.common import RawActivations
+
+
+def run_once(snapshot: str, seq_len: int, staged: bool) -> tuple[float, object]:
+    os.environ["FPWAP_STAGED_LOAD"] = "1" if staged else "0"
+    torch.manual_seed(0)
+    item = {
+        "input_ids": torch.randint(0, 50_000, (seq_len,), dtype=torch.long),
+        "attention_mask": torch.ones(seq_len, dtype=torch.long),
+    }
+    sweep = Sweep(
+        model=snapshot,
+        dataset=[item],
+        seq_len=seq_len,
+        callbacks=[
+            RawActivations(layers=[24, 41], hook="residual_post", last_token_only=False)
+        ],
+        microbatch_size=1,
+        execution_device="cuda",
+        progress=False,
+    )
+    t0 = time.perf_counter()
+    result = sweep.run()
+    wall = time.perf_counter() - t0
+    return wall, result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--snapshot", required=True)
+    ap.add_argument("--seq-len", type=int, default=16384)
+    args = ap.parse_args()
+    snapshot = str(Path(args.snapshot).expanduser())
+
+    runs: list[tuple[str, float, object]] = []
+    for label, staged in (("staged#1", True), ("legacy", False), ("staged#2", True)):
+        wall, result = run_once(snapshot, args.seq_len, staged)
+        prof = result.profile
+        load = sum(t.load_s for t in prof.per_layer.values())
+        fwd = sum(t.forward_s for t in prof.per_layer.values())
+        n_layers = len(prof.per_layer)
+        print(
+            f"{label:9s} wall {wall:7.2f}s | {n_layers} layers | "
+            f"load {load:6.2f}s  fwd {fwd:6.2f}s | "
+            f"{wall / n_layers:5.2f} s/layer"
+        )
+        runs.append((label, wall, result))
+
+    ref = runs[1][2]
+    for label, _, result in (runs[0], runs[2]):
+        for layer in (24, 41):
+            a = ref.activations(layer, "residual_post")
+            b = result.activations(layer, "residual_post")
+            exact = torch.equal(a, b)
+            print(f"bitwise {label} vs legacy @ layer {layer}: {exact}")
+            if not exact:
+                diff = (a.float() - b.float()).abs().max().item()
+                print(f"  max abs diff: {diff}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_load_components.py
+++ b/scripts/profile_load_components.py
@@ -1,0 +1,91 @@
+"""Component profile of one layer's load path on a real snapshot.
+
+Times, for one MoE layer:
+  1. loader[name] for every param (safetensors get_tensor / conversion)
+  2. copy of those tensors into a pinned buffer
+  3. one async H2D from pinned
+  4. legacy per-tensor set_module_tensor_to_device path
+Run twice back-to-back: pass 2 shows the page-cache-warm numbers.
+
+Usage:
+    uv run scripts/profile_load_components.py --snapshot <dir> --layer 10
+"""
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+import torch
+
+from fpwap.engine import _OffloadStreamer
+from fpwap.loader import build_empty_model_and_index
+from fpwap.models import get_plumbing
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--snapshot", required=True)
+    ap.add_argument("--layer", type=int, default=10)
+    args = ap.parse_args()
+    snap = Path(args.snapshot).expanduser()
+
+    model, accel_index, _ = build_empty_model_and_index(str(snap), snap)
+    model.eval()
+    plumbing = get_plumbing(model)
+    streamer = _OffloadStreamer(accel_index, torch.device("cuda"), model=model)
+    loader = streamer._loader
+    layer = plumbing.layer_modules(model)[args.layer]
+    prefix = plumbing.layer_prefix(args.layer)
+
+    names = [rel for rel, _ in layer.named_parameters()]
+    print(f"layer {args.layer}: {len(names)} params")
+
+    for pass_idx in (1, 2):
+        t0 = time.perf_counter()
+        tensors = {rel: loader[f"{prefix}.{rel}"] for rel in names}
+        t_read = time.perf_counter() - t0
+        total = sum(t.element_size() * t.numel() for t in tensors.values())
+        gb = total / 1e9
+
+        pinned = torch.empty(total, dtype=torch.uint8, pin_memory=True)
+        t0 = time.perf_counter()
+        off = 0
+        for rel in names:
+            t = tensors[rel]
+            n = t.element_size() * t.numel()
+            pinned[off : off + n].view(t.dtype).view(t.shape).copy_(t)
+            off += n
+        t_fill = time.perf_counter() - t0
+
+        dev = torch.empty(total, dtype=torch.uint8, device="cuda")
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        dev.copy_(pinned, non_blocking=True)
+        torch.cuda.synchronize()
+        t_h2d = time.perf_counter() - t0
+
+        print(
+            f"pass {pass_idx}: {gb:.2f} GB | "
+            f"read {t_read:.3f}s ({gb / t_read:.1f} GB/s) | "
+            f"pin-fill {t_fill:.3f}s ({gb / t_fill:.1f} GB/s) | "
+            f"H2D {t_h2d:.3f}s ({gb / t_h2d:.1f} GB/s)"
+        )
+        del tensors, pinned, dev
+
+    # Legacy path for reference (loads layer onto cuda, per-tensor).
+    from fpwap.loader import _load_layer, _unload_layer
+
+    for pass_idx in (1, 2):
+        _unload_layer(model, args.layer, plumbing)
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        _load_layer(model, args.layer, plumbing, loader, torch.device("cuda"))
+        torch.cuda.synchronize()
+        t_legacy = time.perf_counter() - t0
+        print(f"legacy per-tensor load pass {pass_idx}: {t_legacy:.3f}s")
+    streamer.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import time
 import uuid
@@ -440,7 +441,17 @@ class _LayerStreamer:
 
     def load_layer(
         self, model: nn.Module, layer_idx: int, plumbing: ModelPlumbing
-    ) -> None:
+    ) -> Any | None:
+        """Load layer weights onto the execution device.
+
+        May return an opaque readiness handle (a CUDA event for async
+        staged loads); the caller must pass it to `wait_load_ready` before
+        computing with the layer. None means the load is already complete.
+        """
+        return None
+
+    def wait_load_ready(self, handle: Any | None) -> None:
+        """Order the current compute stream after an async staged load."""
         return None
 
     def unload_layer(
@@ -452,7 +463,8 @@ class _LayerStreamer:
         self, model: nn.Module, layer_idx: int, plumbing: ModelPlumbing
     ) -> Any | None:
         """Return a handle (future-like) that the engine can wait on, or
-        None if this streamer doesn't do prefetch."""
+        None if this streamer doesn't do prefetch. The future resolves to
+        the readiness handle for `wait_load_ready`."""
         return None
 
     def prefetch_chunk(
@@ -503,6 +515,21 @@ class _OffloadStreamer(_LayerStreamer):
         self._loader = loader
         self._accel_index = accel_index
         self.last_load_bytes = 0
+        # Pinned-staging fast path: read each layer's bytes straight from
+        # the shards into a pinned host buffer and issue one async H2D per
+        # layer, instead of per-param get_tensor + synchronous pageable
+        # copies. Kill switch: FPWAP_STAGED_LOAD=0 restores the legacy path.
+        from fpwap.loader import StagedLayerLoader
+
+        self._staged: StagedLayerLoader | None = None
+        if (
+            execution_device.type == "cuda"
+            and torch.cuda.is_available()
+            and os.environ.get("FPWAP_STAGED_LOAD", "1") != "0"
+        ):
+            self._staged = StagedLayerLoader(
+                loader, execution_device, accel_index=accel_index, plans=plans
+            )
         virtual_sources = {
             target: [key for key, _ in plan.sources]
             for target, plan in plans.items()
@@ -530,13 +557,24 @@ class _OffloadStreamer(_LayerStreamer):
 
     def load_layer(
         self, model: nn.Module, layer_idx: int, plumbing: ModelPlumbing
-    ) -> None:
-        _load_layer(model, layer_idx, plumbing, self._loader, self.execution_device)
+    ) -> Any | None:
+        handle: Any | None = None
+        if self._staged is not None:
+            handle = self._staged.load_layer(model, layer_idx, plumbing)
+        else:
+            _load_layer(
+                model, layer_idx, plumbing, self._loader, self.execution_device
+            )
         layer = plumbing.layer_modules(model)[layer_idx]
         bytes_loaded = 0
         for _, p in layer.named_parameters():
             bytes_loaded += p.element_size() * p.numel()
         self.last_load_bytes = bytes_loaded
+        return handle
+
+    def wait_load_ready(self, handle: Any | None) -> None:
+        if handle is not None:
+            torch.cuda.current_stream(self.execution_device).wait_event(handle)
 
     def unload_layer(
         self, model: nn.Module, layer_idx: int, plumbing: ModelPlumbing
@@ -565,9 +603,13 @@ class _OffloadStreamer(_LayerStreamer):
         if self._prefetch_pool is None:
             return None
 
-        def _load_all() -> None:
+        def _load_all() -> Any | None:
+            # The copy stream is sequential, so the last layer's readiness
+            # handle implies completion of every earlier staged copy.
+            handle: Any | None = None
             for li in layer_indices:
-                self.load_layer(model, li, plumbing)
+                handle = self.load_layer(model, li, plumbing)
+            return handle
 
         return self._prefetch_pool.submit(_load_all)
 
@@ -575,6 +617,8 @@ class _OffloadStreamer(_LayerStreamer):
         if self._prefetch_pool is not None:
             self._prefetch_pool.shutdown(wait=True)
             self._prefetch_pool = None
+        if self._staged is not None:
+            self._staged.close()
 
 
 def _make_chunks(n_layers: int, chunk_size: int) -> list[range]:
@@ -1440,13 +1484,17 @@ class Sweep:
                 is_last_in_chunk = layer_idx == chunk.stop - 1
                 has_scratch = bool(gpu_scratch)
 
-                # Load this layer (wait for prefetch, or sync load).
+                # Load this layer (wait for prefetch, or sync load). Staged
+                # loads return a readiness handle: the H2D copy may still be
+                # in flight on the copy stream, so order the compute stream
+                # behind it before any of this layer's kernels are enqueued.
                 t_load = time.perf_counter_ns()
                 if prefetch_future is not None:
-                    prefetch_future.result()
+                    load_handle = prefetch_future.result()
                     prefetch_future = None
                 else:
-                    streamer.load_layer(model, layer_idx, plumbing)
+                    load_handle = streamer.load_layer(model, layer_idx, plumbing)
+                streamer.wait_load_ready(load_handle)
                 timing.load_s = (time.perf_counter_ns() - t_load) / 1e9
                 timing.bytes_weights = streamer.last_load_bytes
 

--- a/src/fpwap/loader.py
+++ b/src/fpwap/loader.py
@@ -422,6 +422,315 @@ def _load_named_param(
     )
 
 
+_STAGED_ALIGN = 64  # byte alignment for tensors packed into the staging buffer
+_STAGED_READ_THREADS = 8  # preadv workers; reads release the GIL
+
+
+@dataclass
+class _SourceRange:
+    """One contiguous byte range of checkpoint data backing (part of) a param."""
+
+    path: str
+    start: int
+    nbytes: int
+
+
+def _close_fds(fds: dict[str, int]) -> None:
+    for fd in fds.values():
+        os.close(fd)
+    fds.clear()
+
+
+class StagedLayerLoader:
+    """Pinned-staging layer loader: direct byte reads + one async H2D per layer.
+
+    The per-tensor path (`_load_layer`) is load-bound twice over: each
+    param goes through safetensors `get_tensor` (a fresh pageable CPU
+    tensor per call — and for transformers ≥5 fused-MoE params, through
+    the whole checkpoint-conversion machinery per layer), then through a
+    `set_module_tensor_to_device(..., non_blocking=True)` whose
+    `non_blocking` is silently synchronous from pageable memory. Measured
+    on a Qwen3-30B-A3B MoE layer: ~1 GB/s effective against a gen5 x16
+    link that does ~25× that from pinned memory, with the whole sweep
+    load-bound.
+
+    This loader cuts both costs:
+
+    - **Reads**: each param's bytes are `preadv`'d straight from the
+      safetensors shards into a reused pinned host buffer on a small
+      thread pool (the read releases the GIL; offsets come from the shard
+      headers). Fused params produced by checkpoint conversion are
+      assembled by concatenating their source ranges in plan order — and
+      the first time each param pattern is assembled, the result is
+      verified bitwise against the conversion machinery's output; a
+      pattern that doesn't match byte-concatenation permanently falls
+      back to the tensor path (`loader[name]` → copy into pinned), so the
+      fast path can never silently produce different weights.
+    - **Copies**: ONE genuinely-async H2D from the pinned buffer into a
+      fresh contiguous device buffer on a dedicated copy stream; params
+      install as views into that buffer.
+
+    Contract with the engine:
+
+    - `load_layer` returns a `torch.cuda.Event` recorded on the copy
+      stream after the H2D copy, or None when it fell back to the
+      per-tensor path. The caller must make its compute stream wait on the
+      event (`Sweep.run` does, via `streamer.wait_load_ready`) before
+      running the layer forward.
+    - Unloading is unchanged: `_unload_layer`'s meta re-install drops the
+      param views, freeing the device buffer back to the caching
+      allocator. The buffer is `record_stream`-marked against the copy
+      stream so the allocator won't recycle it under an in-flight copy.
+    - Install semantics mirror `set_module_tensor_to_device` for the
+      plain-Parameter meta→device case: checkpoint values are cast to the
+      meta param's dtype, shape mismatches raise, and a fresh
+      `nn.Parameter` replaces the placeholder. Layers with exotic param
+      subclasses (quantized wrappers etc.) fall back to `_load_layer`,
+      as does the whole loader if pinned allocation fails.
+
+    Loads are serialized by the engine (one outstanding prefetch), so a
+    single pinned buffer suffices: each fill waits host-side on the
+    previous layer's copy event before reusing the buffer.
+    """
+
+    def __init__(
+        self,
+        loader: Any,
+        device: torch.device,
+        accel_index: dict[str, dict[str, Any]] | None = None,
+        plans: dict[str, WeightConversionPlan] | None = None,
+    ) -> None:
+        self._loader = loader
+        self._device = device
+        self._accel_index = accel_index or {}
+        self._plans = plans or {}
+        self._copy_stream = torch.cuda.Stream(device=device)  # type: ignore[no-untyped-call]
+        self._pinned: torch.Tensor | None = None
+        self._pending: torch.cuda.Event | None = None
+        self._broken = False  # pinned alloc failed; permanent fallback
+        self._offsets: dict[str, dict[str, tuple[int, int]]] = {}
+        self._fds: dict[str, int] = {}
+        self._pool: Any | None = None
+        # Byte-assembly trust state, keyed by layer-relative param name
+        # (layers are structurally identical, so one verification covers
+        # the pattern across all layers).
+        self._verified: set[str] = set()
+        self._tensor_path: set[str] = set()
+        # Safety net: close shard fds on GC if close() is never reached
+        # (holds the dict, not self, so the finalizer doesn't pin the loader).
+        import weakref
+
+        weakref.finalize(self, _close_fds, self._fds)
+
+    def close(self) -> None:
+        # The last H2D may still be in flight on the copy stream; it reads
+        # from the pinned buffer this loader owns, so drain it before the
+        # buffer can be garbage-collected.
+        if self._pending is not None:
+            self._pending.synchronize()
+            self._pending = None
+        if self._pool is not None:
+            self._pool.shutdown(wait=True)
+            self._pool = None
+        _close_fds(self._fds)
+
+    def _range_of_key(self, key: str) -> _SourceRange | None:
+        entry = self._accel_index.get(key)
+        if entry is None:
+            return None
+        path = entry["safetensors_file"]
+        st_name = entry.get("weight_name", key)
+        if path not in self._offsets:
+            self._offsets[path] = _parse_safetensors_offsets(path)
+        rng = self._offsets[path].get(st_name)
+        if rng is None:
+            return None
+        start, end = rng
+        return _SourceRange(path, start, end - start)
+
+    def _ranges_for(self, full_name: str, param: nn.Parameter) -> list[_SourceRange] | None:
+        """Byte ranges whose concatenation should equal the param's bytes.
+
+        None when the param can't be byte-assembled (unknown key, dtype
+        mismatch vs the module, one-to-many conversion, size mismatch) —
+        callers then use the tensor path.
+        """
+        plan = self._plans.get(full_name)
+        if plan is not None:
+            if len(plan.targets) != 1:
+                return None  # one-to-many (qkv split etc.): not concatenation
+            keys = [k for k, _ in plan.sources]
+        else:
+            keys = [full_name]
+        ranges: list[_SourceRange] = []
+        module_dtype = str(param.dtype).removeprefix("torch.")
+        for key in keys:
+            entry = self._accel_index.get(key)
+            if entry is None or str(entry.get("dtype", "")) != module_dtype:
+                return None
+            rng = self._range_of_key(key)
+            if rng is None:
+                return None
+            ranges.append(rng)
+        if sum(r.nbytes for r in ranges) != param.element_size() * param.numel():
+            return None
+        return ranges
+
+    def _fd(self, path: str) -> int:
+        fd = self._fds.get(path)
+        if fd is None:
+            fd = os.open(path, os.O_RDONLY)
+            self._fds[path] = fd
+        return fd
+
+    def load_layer(
+        self, model: nn.Module, layer_idx: int, plumbing: Any
+    ) -> torch.cuda.Event | None:
+        layer = plumbing.layer_modules(model)[layer_idx]
+        prefix = plumbing.layer_prefix(layer_idx)
+
+        # Pack plan: (rel_name, meta_param, byte_offset, nbytes).
+        entries: list[tuple[str, nn.Parameter, int, int]] = []
+        total = 0
+        fallback = self._broken
+        for rel_name, param in layer.named_parameters():
+            if type(param) is not nn.Parameter:
+                fallback = True
+                break
+            offset = -(-total // _STAGED_ALIGN) * _STAGED_ALIGN
+            nbytes = param.element_size() * param.numel()
+            entries.append((rel_name, param, offset, nbytes))
+            total = offset + nbytes
+        if fallback:
+            _load_layer(model, layer_idx, plumbing, self._loader, self._device)
+            return None
+
+        # Host fill: wait for the previous layer's H2D to release the pinned
+        # buffer, then pack every tensor back-to-back at the param's dtype.
+        if self._pending is not None:
+            self._pending.synchronize()
+            self._pending = None
+        if self._pinned is None or self._pinned.numel() < total:
+            self._pinned = None
+            try:
+                self._pinned = torch.empty(
+                    total, dtype=torch.uint8, pin_memory=True
+                )
+            except RuntimeError:
+                self._broken = True
+                _load_layer(model, layer_idx, plumbing, self._loader, self._device)
+                return None
+        self._fill_pinned(entries, prefix)
+
+        assert self._pinned is not None
+        # One async H2D into a fresh device buffer on the copy stream. The
+        # buffer's home stream is this thread's current (compute) stream, so
+        # post-unload reuse by compute-stream allocations is ordered; the
+        # record_stream covers the cross-stream write.
+        dev = torch.empty(total, dtype=torch.uint8, device=self._device)
+        event = torch.cuda.Event()  # type: ignore[no-untyped-call]
+        with torch.cuda.stream(self._copy_stream):
+            dev.copy_(self._pinned[:total], non_blocking=True)
+            event.record(self._copy_stream)
+        dev.record_stream(self._copy_stream)
+
+        # Install params as views into the device buffer (the meta→real
+        # transition only needs a fresh Parameter in module._parameters,
+        # exactly what set_module_tensor_to_device does underneath).
+        for rel_name, param, offset, nbytes in entries:
+            view = dev[offset : offset + nbytes].view(param.dtype).view(param.shape)
+            submod_path, _, leaf = rel_name.rpartition(".")
+            submod = layer.get_submodule(submod_path) if submod_path else layer
+            submod._parameters[leaf] = nn.Parameter(
+                view, requires_grad=param.requires_grad
+            )
+        self._pending = event
+        return event
+
+    def _fill_pinned(
+        self, entries: list[tuple[str, nn.Parameter, int, int]], prefix: str
+    ) -> None:
+        """Pack every param's bytes into the pinned buffer.
+
+        Byte-assemblable params are read with preadv on a thread pool;
+        the rest go through `loader[name]` (conversion machinery / dtype
+        cast) on this thread while the pool drains. First-time byte
+        assemblies are verified bitwise against the tensor path before
+        the pattern is trusted.
+        """
+        import concurrent.futures as _cf
+
+        assert self._pinned is not None
+        pinned_mv = memoryview(self._pinned.numpy())  # type: ignore[arg-type]
+
+        byte_jobs: list[tuple[str, nn.Parameter, int, int, list[_SourceRange]]] = []
+        tensor_jobs: list[tuple[str, nn.Parameter, int, int]] = []
+        for rel_name, param, offset, nbytes in entries:
+            ranges = (
+                None
+                if rel_name in self._tensor_path
+                else self._ranges_for(f"{prefix}.{rel_name}", param)
+            )
+            if ranges is None:
+                tensor_jobs.append((rel_name, param, offset, nbytes))
+            else:
+                byte_jobs.append((rel_name, param, offset, nbytes, ranges))
+
+        futures: list[Any] = []
+        if byte_jobs:
+            if self._pool is None:
+                self._pool = _cf.ThreadPoolExecutor(
+                    max_workers=_STAGED_READ_THREADS,
+                    thread_name_prefix="fpwap-staged-read",
+                )
+
+            def _read(path: str, start: int, dst_lo: int, dst_hi: int) -> None:
+                os.preadv(self._fd(path), [pinned_mv[dst_lo:dst_hi]], start)
+
+            for _, _, offset, _, ranges in byte_jobs:
+                dst = offset
+                for rng in ranges:
+                    futures.append(
+                        self._pool.submit(_read, rng.path, rng.start, dst, dst + rng.nbytes)
+                    )
+                    dst += rng.nbytes
+
+        for rel_name, param, offset, nbytes in tensor_jobs:
+            value = self._loader[f"{prefix}.{rel_name}"]
+            if value.shape != param.shape:
+                raise ValueError(
+                    f"checkpoint tensor {prefix}.{rel_name} has shape "
+                    f"{tuple(value.shape)}, module expects {tuple(param.shape)}"
+                )
+            staged = self._pinned[offset : offset + nbytes]
+            staged.view(param.dtype).view(param.shape).copy_(value)
+
+        for fut in futures:
+            fut.result()
+
+        # First use of each pattern: prove byte concatenation reproduces the
+        # conversion machinery's output before trusting it for later layers.
+        for rel_name, param, offset, nbytes, _ in byte_jobs:
+            if rel_name in self._verified:
+                continue
+            staged = self._pinned[offset : offset + nbytes]
+            view = staged.view(param.dtype).view(param.shape)
+            reference = self._loader[f"{prefix}.{rel_name}"]
+            if reference.shape == param.shape and torch.equal(
+                view, reference.to(param.dtype)
+            ):
+                self._verified.add(rel_name)
+            else:
+                self._tensor_path.add(rel_name)
+                if reference.shape != param.shape:
+                    raise ValueError(
+                        f"checkpoint tensor {prefix}.{rel_name} has shape "
+                        f"{tuple(reference.shape)}, module expects "
+                        f"{tuple(param.shape)}"
+                    )
+                view.copy_(reference)
+
+
 def _unload_layer(model: nn.Module, layer_idx: int, plumbing: Any) -> None:
     """Release layer `layer_idx` weights back to the meta device.
 

--- a/tests/gpu/test_staged_layer_load.py
+++ b/tests/gpu/test_staged_layer_load.py
@@ -1,0 +1,182 @@
+"""Contract for StagedLayerLoader (pinned-staging single-H2D layer loads).
+
+Same shard-on-disk setup as tests/unit/test_loader_layer.py, but loads
+through _OffloadStreamer on CUDA — which routes through StagedLayerLoader —
+and checks bit-exactness against the source weights, meta restoration on
+unload, reload after unload (pinned-buffer + copy-event reuse), and the
+FPWAP_STAGED_LOAD=0 kill switch.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from fpwap.engine import _OffloadStreamer
+from fpwap.loader import (
+    alias_tied_weights_in_index,
+    build_accel_index_from_hf_cache,
+)
+from fpwap.models import get_plumbing
+
+pytestmark = pytest.mark.gpu
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="needs a CUDA device"
+)
+
+
+def _write_tiny_gpt2_shard(tmp_path: Path) -> tuple[torch.nn.Module, torch.nn.Module]:
+    """Save a tiny GPT-2's state_dict to safetensors under tmp_path.
+
+    Returns (source_model_with_real_weights, empty_twin_on_meta_device).
+    """
+    from accelerate import init_empty_weights
+    from transformers import GPT2Config, GPT2LMHeadModel
+
+    config = GPT2Config(
+        vocab_size=40,
+        n_positions=8,
+        n_embd=16,
+        n_layer=2,
+        n_head=2,
+    )
+    torch.manual_seed(0)
+    src = GPT2LMHeadModel(config)
+    src.eval()
+
+    tied_alias = "lm_head.weight"
+    state_dict = {
+        k: v.contiguous() for k, v in src.state_dict().items() if k != tied_alias
+    }
+    save_file(state_dict, tmp_path / "model.safetensors")
+    hf_index = {
+        "metadata": {"total_size": 0},
+        "weight_map": {k: "model.safetensors" for k in state_dict},
+    }
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(hf_index))
+
+    with init_empty_weights():
+        dst = GPT2LMHeadModel(config)
+    dst.tie_weights()
+    return src, dst
+
+
+def _make_streamer(tmp_path: Path) -> tuple[
+    torch.nn.Module, torch.nn.Module, _OffloadStreamer
+]:
+    src, dst = _write_tiny_gpt2_shard(tmp_path)
+    accel_index = build_accel_index_from_hf_cache(tmp_path)
+    alias_tied_weights_in_index(dst, accel_index)
+    streamer = _OffloadStreamer(accel_index, torch.device("cuda"), model=dst)
+    return src, dst, streamer
+
+
+@requires_cuda
+def test_staged_load_matches_source_bit_exact(tmp_path: Path) -> None:
+    src, dst, streamer = _make_streamer(tmp_path)
+    plumbing = get_plumbing(dst)
+    assert streamer._staged is not None, "staged path should be active on CUDA"
+
+    handle = streamer.load_layer(dst, 0, plumbing)
+    assert handle is not None, "staged load should return a readiness event"
+    streamer.wait_load_ready(handle)
+    torch.cuda.synchronize()
+
+    src_layer = plumbing.layer_modules(src)[0]
+    dst_layer = plumbing.layer_modules(dst)[0]
+    for (src_name, src_p), (dst_name, dst_p) in zip(
+        src_layer.named_parameters(), dst_layer.named_parameters(), strict=True
+    ):
+        assert src_name == dst_name
+        assert type(dst_p) is torch.nn.Parameter
+        assert dst_p.device.type == "cuda", f"{dst_name} not on cuda"
+        assert dst_p.requires_grad == src_p.requires_grad
+        assert torch.equal(src_p.cuda(), dst_p), f"value mismatch at {dst_name}"
+    streamer.close()
+
+
+@requires_cuda
+def test_staged_unload_and_reload(tmp_path: Path) -> None:
+    src, dst, streamer = _make_streamer(tmp_path)
+    plumbing = get_plumbing(dst)
+
+    streamer.wait_load_ready(streamer.load_layer(dst, 0, plumbing))
+    streamer.unload_layer(dst, 0, plumbing)
+    dst_layer = plumbing.layer_modules(dst)[0]
+    for name, p in dst_layer.named_parameters():
+        assert p.device.type == "meta", f"{name} not back on meta after unload"
+
+    # Reload exercises pinned-buffer reuse + the copy-event wait path.
+    streamer.wait_load_ready(streamer.load_layer(dst, 0, plumbing))
+    torch.cuda.synchronize()
+    src_layer = plumbing.layer_modules(src)[0]
+    for (name, src_p), (_, dst_p) in zip(
+        src_layer.named_parameters(), dst_layer.named_parameters(), strict=True
+    ):
+        assert torch.equal(src_p.cuda(), dst_p), f"reload mismatch at {name}"
+    streamer.close()
+
+
+@requires_cuda
+def test_staged_forward_bit_exact_vs_legacy_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same device, same kernels — only the load path differs."""
+    torch.manual_seed(1)
+    hs = torch.randn(2, 8, 16, device="cuda")
+
+    monkeypatch.setenv("FPWAP_STAGED_LOAD", "0")
+    _, legacy_dst, legacy_streamer = _make_streamer(tmp_path)
+    legacy_plumbing = get_plumbing(legacy_dst)
+    legacy_streamer.wait_load_ready(legacy_streamer.load_layer(legacy_dst, 0, legacy_plumbing))
+    with torch.no_grad():
+        ref = legacy_plumbing.layer_modules(legacy_dst)[0](hs)[0]
+    legacy_streamer.close()
+
+    monkeypatch.delenv("FPWAP_STAGED_LOAD")
+    _, dst, streamer = _make_streamer(tmp_path)
+    plumbing = get_plumbing(dst)
+    assert streamer._staged is not None
+    streamer.wait_load_ready(streamer.load_layer(dst, 0, plumbing))
+    with torch.no_grad():
+        got = plumbing.layer_modules(dst)[0](hs)[0]
+    torch.cuda.synchronize()
+    assert torch.equal(ref, got), "staged forward diverged from legacy path"
+    streamer.close()
+
+
+@requires_cuda
+def test_kill_switch_disables_staged_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FPWAP_STAGED_LOAD", "0")
+    src, dst, streamer = _make_streamer(tmp_path)
+    plumbing = get_plumbing(dst)
+    assert streamer._staged is None
+
+    handle = streamer.load_layer(dst, 0, plumbing)
+    assert handle is None
+    streamer.wait_load_ready(handle)  # no-op
+    src_layer = plumbing.layer_modules(src)[0]
+    dst_layer = plumbing.layer_modules(dst)[0]
+    for (name, src_p), (_, dst_p) in zip(
+        src_layer.named_parameters(), dst_layer.named_parameters(), strict=True
+    ):
+        assert torch.equal(src_p.cuda(), dst_p), f"legacy-path mismatch at {name}"
+    streamer.close()
+
+
+def test_cpu_streamer_has_no_staged_loader(tmp_path: Path) -> None:
+    """CPU execution keeps the legacy path (runs in CI without a GPU)."""
+    _, dst = _write_tiny_gpt2_shard(tmp_path)
+    accel_index = build_accel_index_from_hf_cache(tmp_path)
+    alias_tied_weights_in_index(dst, accel_index)
+    streamer = _OffloadStreamer(accel_index, torch.device("cpu"), model=dst)
+    assert streamer._staged is None
+    plumbing = get_plumbing(dst)
+    assert streamer.load_layer(dst, 0, plumbing) is None
+    streamer.close()


### PR DESCRIPTION
## Problem

Reported from the lens m3 backfill (Qwen3-Coder-30B-A3B bf16-dequant reader, RTX 5090): every sweep took a flat ~53s regardless of shard token count — entirely load-bound at ~1 GB/s effective, ~40× under what gen5 x16 does from pinned memory. The `per_layer = max(load, compute)` prefetch overlap had nothing to overlap against.

Component profiling found **two stacked causes** (the original handoff only identified the second):

1. **The source read dominates** (~0.8s/layer even page-cache-warm): per-param safetensors `get_tensor`, and for transformers ≥5 fused-MoE params the whole checkpoint-conversion machinery (384 small reads + concat + per-key converter deep-copies) runs per layer.
2. `set_module_tensor_to_device(..., non_blocking=True)` from **pageable** memory is silently synchronous — per-param copies serialize through CUDA's bounce buffer (~0.16s/layer plus contention with compute).

## Fix

`StagedLayerLoader` (CUDA streaming path only):

- **Reads**: `preadv` each param's bytes straight from the safetensors shards into a reused pinned host buffer on an 8-thread pool (offsets from shard headers, GIL released). Fused params are assembled by concatenating their conversion-plan source ranges in plan order.
- **Trust but verify**: the first time each param pattern is byte-assembled, the result is compared bitwise against the conversion machinery's output; mismatching patterns permanently fall back to the tensor path. The fast path can never silently produce different weights. (On Qwen3-MoE all 11 patterns verify, including `mlp.experts.gate_up_proj` / `down_proj`.)
- **Copies**: one genuinely-async H2D per layer on a dedicated copy stream; params install as views into the contiguous device buffer. The engine orders the compute stream behind the copy event via the new `streamer.wait_load_ready` before enqueueing the layer's kernels.
- **Fallback ladder**: `FPWAP_STAGED_LOAD=0` kill switch, non-CUDA devices, exotic param subclasses, pinned-alloc failure, dtype mismatch, one-to-many conversions (qkv splits) — all land on the existing `_load_layer` path.

## Measurements

`scripts/bench_staged_load.py`, Qwen3-Coder-30B-A3B bf16 snapshot, 16k tokens, microbatch 1, layers 0–41, RTX 5090:

| run | wall | load stall | fwd (enqueue) |
|---|---|---|---|
| staged #1 | 13.46s | 3.40s | 1.44s |
| legacy | 54.70s | 32.99s | 16.45s |
| staged #2 | 12.01s | 3.11s | 1.09s |

Activations **bitwise identical** to the legacy path at layers 24 and 41 in every run. Steady-state layer load 0.30s vs 0.93s; the sweep is compute-bound again. For the lens m3 workload this turns a two-GPU-evening materialization into a ~15-minute job.

## Validation

- mypy strict + ruff clean
- 285 unit/integration tests pass (CPU)
- GPU suite incl. `test_moe_streaming_bit_exact` (converted-checkpoint fused-MoE bit-exactness through the staged path) passes
- New `tests/gpu/test_staged_layer_load.py`: bit-exact weights vs source, unload/reload, bitwise forward vs legacy path, kill switch, CPU fallback
- `scripts/profile_load_components.py` kept for future load-path forensics

🤖 Generated with [Claude Code](https://claude.com/claude-code)