### PR TITLE
release 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fpwap"
-version = "0.1.1"
+version = "0.1.2"
 description = "Forward Pass Weight Amortization Protocol — invert the inference loop for large transformer models."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps the version so release.yml tags and publishes to PyPI on merge.

0.1.2 ships #80 — staged layer loads (direct shard byte-reads into a pinned buffer + one async H2D per layer, first-use bitwise verification of fused-param byte assembly). ~4.6× on load-bound MoE sweeps, bitwise-identical activations, `FPWAP_STAGED_LOAD=0` kill switch.

**Merging this publishes 0.1.2 to PyPI.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)