### PR TITLE
Resident page-cache budget: stop multi-shard sweeps re-reading the snapshot every shard (0.1.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fpwap"
-version = "0.1.2"
+version = "0.1.3"
 description = "Forward Pass Weight Amortization Protocol — invert the inference loop for large transformer models."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fpwap/loader.py
+++ b/src/fpwap/loader.py
@@ -17,6 +17,49 @@ from torch import nn
 _HAS_POSIX_FADVISE = hasattr(os, "posix_fadvise")
 
 
+def _phys_ram_bytes() -> int:
+    try:
+        return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+    except (ValueError, OSError, AttributeError):
+        return 0
+
+
+def _resident_page_budget() -> int:
+    """Byte budget for weight pages held resident in the page cache.
+
+    ``DONTNEED``-after-unload frees a layer's pages so the kernel can reclaim
+    them for the next layer. That is necessary when the *touched* weight set
+    exceeds host RAM, but actively harmful when it fits: it forces every sweep
+    to re-read the shards from disk instead of reusing the warm page cache, so
+    a workload that streams many shards (each a full layer sweep) runs
+    disk-bound at the snapshot's read rate.
+
+    The advisor keeps touched layers resident up to this budget and only
+    DONTNEEDs beyond it (see ``ShardPageAdvisor.advise_dontneed``). Truncated
+    sweeps (an activations-only profile stops at the deepest probed layer) and
+    repeated reads then run compute-bound; a full-depth sweep larger than the
+    budget fills it and evicts the rest gracefully. The budget is a fraction
+    of total RAM rather than the whole snapshot, so the policy is correct even
+    when the full snapshot is larger than RAM but the swept prefix is not.
+
+    ``0`` disables resident caching (restores the always-DONTNEED behavior).
+    Override the whole policy with ``FPWAP_PAGE_RESIDENT=0`` (off) or set the
+    budget directly with ``FPWAP_PAGE_RESIDENT_GB=<n>``.
+    """
+    if os.environ.get("FPWAP_PAGE_RESIDENT") in ("0", "false", "False"):
+        return 0
+    gb = os.environ.get("FPWAP_PAGE_RESIDENT_GB")
+    if gb is not None:
+        try:
+            return int(float(gb) * 1e9)
+        except ValueError:
+            pass
+    ram = _phys_ram_bytes()
+    # Leave ~40% of RAM for activation/emit buffers, pinned staging buffers,
+    # other processes, and the kernel's own reclaim headroom.
+    return int(0.6 * ram) if ram > 0 else 0
+
+
 def resolve_snapshot_dir(model: str) -> Path:
     """Resolve `model` to a local HF snapshot directory.
 
@@ -770,8 +813,12 @@ def _parse_safetensors_offsets(path: str) -> dict[str, tuple[int, int]]:
 class ShardPageAdvisor:
     """Advises the kernel about page cache for safetensors shards.
 
-    Uses posix_fadvise(DONTNEED) after a layer is unloaded so the kernel
-    can reclaim those pages for upcoming layers. On non-Linux platforms
+    Uses posix_fadvise(DONTNEED) after a layer is unloaded so the kernel can
+    reclaim those pages for upcoming layers — but only once the resident
+    weight set exceeds the page budget (see ``_resident_page_budget``). Touched
+    layers within the budget are kept resident so the page cache stays warm
+    across sweeps and repeated / truncated multi-shard reads run compute-bound
+    rather than re-reading shards from disk each sweep. On non-Linux platforms
     (no posix_fadvise), all methods are silent no-ops.
 
     `virtual_sources` maps module param names that don't exist on disk
@@ -787,7 +834,11 @@ class ShardPageAdvisor:
     ) -> None:
         self._offsets: dict[str, tuple[str, int, int]] = {}
         self._virtual_sources = virtual_sources or {}
+        self._budget = _resident_page_budget()
+        self._resident_keys: set[frozenset[str]] = set()
+        self._resident_bytes = 0
         if not _HAS_POSIX_FADVISE:
+            self._budget = 0
             return
 
         shard_paths: set[str] = set()
@@ -804,6 +855,17 @@ class ShardPageAdvisor:
             if st_name in shard_offsets.get(shard_path, {}):
                 start, end = shard_offsets[shard_path][st_name]
                 self._offsets[weight_name] = (shard_path, start, end)
+
+    def _bytes_for(self, weight_names: list[str]) -> int:
+        expanded: list[str] = []
+        for name in weight_names:
+            expanded.extend(self._virtual_sources.get(name, (name,)))
+        return sum(
+            end - start
+            for name in expanded
+            if name in self._offsets
+            for _, start, end in (self._offsets[name],)
+        )
 
     def _advise(self, weight_names: list[str], advice: int) -> None:
         if not _HAS_POSIX_FADVISE:
@@ -830,6 +892,18 @@ class ShardPageAdvisor:
                 pass
 
     def advise_dontneed(self, weight_names: list[str]) -> None:
+        # Hold touched layers resident in the page cache up to the budget so
+        # repeated / multi-shard sweeps reuse warm pages instead of re-reading
+        # from disk; only evict once the resident set would exceed the budget.
+        if self._budget:
+            key = frozenset(weight_names)
+            if key in self._resident_keys:
+                return
+            layer_bytes = self._bytes_for(weight_names)
+            if self._resident_bytes + layer_bytes <= self._budget:
+                self._resident_keys.add(key)
+                self._resident_bytes += layer_bytes
+                return
         self._advise(weight_names, os.POSIX_FADV_DONTNEED)
 
     def advise_willneed(self, weight_names: list[str]) -> None:

--- a/src/fpwap/loader.py
+++ b/src/fpwap/loader.py
@@ -895,6 +895,15 @@ class ShardPageAdvisor:
         # Hold touched layers resident in the page cache up to the budget so
         # repeated / multi-shard sweeps reuse warm pages instead of re-reading
         # from disk; only evict once the resident set would exceed the budget.
+        #
+        # Eviction is keep-prefix, not LRU: the first layers seen fill the
+        # budget and stay resident for the run; layers encountered after it
+        # fills are DONTNEED'd on every sweep. This is deliberate — lens-style
+        # workloads sweep the *same* layer set over N shards, a cyclic access
+        # pattern on which LRU is pessimal (Belady) while keep-prefix retains
+        # the largest cacheable contiguous prefix. A full-depth sweep larger
+        # than the budget thus stays bounded; a truncated/repeated sweep that
+        # fits runs fully warm.
         if self._budget:
             key = frozenset(weight_names)
             if key in self._resident_keys:

--- a/tests/unit/test_checkpoint_conversion.py
+++ b/tests/unit/test_checkpoint_conversion.py
@@ -222,6 +222,7 @@ class TestAdvisorVirtualSources:
         """fadvise on a fused module param name must hit the underlying
         per-expert checkpoint ranges, or MoE sweeps silently lose page-cache
         discipline (the #61/#69 regime)."""
+        import os
         from unittest.mock import patch
 
         from fpwap.loader import ShardPageAdvisor
@@ -233,10 +234,13 @@ class TestAdvisorVirtualSources:
         sources = [
             f"model.layers.0.mlp.experts.{e}.down_proj.weight" for e in range(4)
         ]
-        advisor = ShardPageAdvisor(
-            accel_index,
-            virtual_sources={"model.layers.0.mlp.experts.down_proj": sources},
-        )
+        # Disable resident caching so this exercises virtual-source range
+        # expansion through an eager DONTNEED, not the budget path.
+        with patch.dict(os.environ, {"FPWAP_PAGE_RESIDENT": "0"}):
+            advisor = ShardPageAdvisor(
+                accel_index,
+                virtual_sources={"model.layers.0.mlp.experts.down_proj": sources},
+            )
 
         with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
             advisor.advise_dontneed(["model.layers.0.mlp.experts.down_proj"])

--- a/tests/unit/test_shard_page_advisor.py
+++ b/tests/unit/test_shard_page_advisor.py
@@ -8,7 +8,12 @@ from unittest.mock import patch
 import torch
 from safetensors.torch import save_file
 
-from fpwap.loader import ShardPageAdvisor, _parse_safetensors_offsets
+from fpwap.loader import (
+    ShardPageAdvisor,
+    _parse_safetensors_offsets,
+    _phys_ram_bytes,
+    _resident_page_budget,
+)
 
 
 def _make_shard(tmp_path: Path, name: str = "model.safetensors") -> Path:
@@ -90,7 +95,10 @@ class TestShardPageAdvisor:
     def test_advise_dontneed_calls_posix_fadvise(self, tmp_path: Path) -> None:
         shard_path = _make_shard(tmp_path)
         index = _make_accel_index(shard_path)
-        advisor = ShardPageAdvisor(index)
+        # Disable resident caching so DONTNEED is issued eagerly (the regime
+        # this test exercises); residency is covered in TestResidentPageCache.
+        with patch.dict(os.environ, {"FPWAP_PAGE_RESIDENT": "0"}):
+            advisor = ShardPageAdvisor(index)
 
         with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
             advisor.advise_dontneed([
@@ -139,7 +147,8 @@ class TestShardPageAdvisor:
     def test_oserror_is_silenced(self, tmp_path: Path) -> None:
         shard_path = _make_shard(tmp_path)
         index = _make_accel_index(shard_path)
-        advisor = ShardPageAdvisor(index)
+        with patch.dict(os.environ, {"FPWAP_PAGE_RESIDENT": "0"}):
+            advisor = ShardPageAdvisor(index)
 
         with patch(
             "fpwap.loader.os.posix_fadvise",
@@ -174,7 +183,8 @@ class TestShardPageAdvisor:
                 "shape": [4, 4],
             },
         }
-        advisor = ShardPageAdvisor(index)
+        with patch.dict(os.environ, {"FPWAP_PAGE_RESIDENT": "0"}):
+            advisor = ShardPageAdvisor(index)
 
         fds_opened: list[str] = []
         original_open = os.open
@@ -188,3 +198,82 @@ class TestShardPageAdvisor:
                 advisor.advise_dontneed(["w0", "w1"])
 
         assert len(fds_opened) == 2
+
+
+class TestResidentPageBudget:
+    def test_default_budget_is_ram_fraction(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FPWAP_PAGE_RESIDENT", None)
+            os.environ.pop("FPWAP_PAGE_RESIDENT_GB", None)
+            budget = _resident_page_budget()
+        assert budget == int(0.6 * _phys_ram_bytes())
+
+    def test_env_disable_returns_zero(self) -> None:
+        with patch.dict(os.environ, {"FPWAP_PAGE_RESIDENT": "0"}):
+            assert _resident_page_budget() == 0
+
+    def test_env_gb_override(self) -> None:
+        with patch.dict(os.environ, {"FPWAP_PAGE_RESIDENT_GB": "2"}):
+            os.environ.pop("FPWAP_PAGE_RESIDENT", None)
+            assert _resident_page_budget() == 2_000_000_000
+
+    def test_env_disable_wins_over_gb(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"FPWAP_PAGE_RESIDENT": "0", "FPWAP_PAGE_RESIDENT_GB": "8"},
+        ):
+            assert _resident_page_budget() == 0
+
+
+class TestResidentPageCache:
+    def test_within_budget_suppresses_dontneed(self, tmp_path: Path) -> None:
+        index = _make_accel_index(_make_shard(tmp_path))
+        advisor = ShardPageAdvisor(index)
+        advisor._budget = 10_000  # bytes — far exceeds the tiny shard
+
+        with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
+            advisor.advise_dontneed(["model.layers.0.self_attn.q_proj.weight"])
+            mock_fadvise.assert_not_called()
+
+        # 4×8 bf16 = 64 bytes held resident.
+        assert advisor._resident_bytes == 4 * 8 * 2
+
+    def test_resident_layer_revisit_counts_once(self, tmp_path: Path) -> None:
+        # A layer re-unloaded on the next sweep stays resident without being
+        # re-counted or evicted — the cross-shard reuse this feature exists for.
+        index = _make_accel_index(_make_shard(tmp_path))
+        advisor = ShardPageAdvisor(index)
+        advisor._budget = 10_000
+        names = ["model.layers.0.self_attn.q_proj.weight"]
+
+        with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
+            advisor.advise_dontneed(names)
+            advisor.advise_dontneed(names)
+            mock_fadvise.assert_not_called()
+
+        assert advisor._resident_bytes == 4 * 8 * 2
+
+    def test_evicts_once_over_budget(self, tmp_path: Path) -> None:
+        # Keep-prefix: the 64-byte layer0 fits and stays resident; the 128-byte
+        # layer1 pushes over budget and is DONTNEED'd.
+        index = _make_accel_index(_make_shard(tmp_path))
+        advisor = ShardPageAdvisor(index)
+        advisor._budget = 4 * 8 * 2  # exactly layer0's size
+
+        with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
+            advisor.advise_dontneed(["model.layers.0.self_attn.q_proj.weight"])
+            assert mock_fadvise.call_count == 0
+            advisor.advise_dontneed(["model.layers.1.self_attn.q_proj.weight"])
+            assert mock_fadvise.call_count == 1
+
+        assert advisor._resident_bytes == 4 * 8 * 2
+
+    def test_disabled_budget_always_evicts(self, tmp_path: Path) -> None:
+        index = _make_accel_index(_make_shard(tmp_path))
+        with patch.dict(os.environ, {"FPWAP_PAGE_RESIDENT": "0"}):
+            advisor = ShardPageAdvisor(index)
+        assert advisor._budget == 0
+
+        with patch("fpwap.loader.os.posix_fadvise") as mock_fadvise:
+            advisor.advise_dontneed(["model.layers.0.self_attn.q_proj.weight"])
+            assert mock_fadvise.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "fpwap"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What

A byte-budgeted resident page cache for `ShardPageAdvisor`: touched layers are kept warm in the OS page cache up to a RAM-fraction budget; `posix_fadvise(DONTNEED)` is only issued once the resident set would exceed it.

Origin: a control-tower-side diagnosis (`HANDOFF-page-resident-multishard.md`) of the **cross-shard** weight re-read — orthogonal to the single-sweep load fix in #80. The advisor `DONTNEED`s every layer after unload, so **repeated** sweeps (N shards over one reader) and **truncated** sweeps (an activations-only profile stops at the deepest probed layer — e.g. ~66 GB of 80, which *fits* in 123 GB RAM) throw away pages the very next shard needs. The cache never warms and every shard re-reads the snapshot from disk regardless of free RAM.

## How

- `_resident_page_budget()` → `0.6 × total_RAM`; `FPWAP_PAGE_RESIDENT=0` disables (restores eager DONTNEED), `FPWAP_PAGE_RESIDENT_GB=<n>` overrides.
- `ShardPageAdvisor` tracks resident layer keys + cumulative bytes; suppresses DONTNEED under budget, evicts beyond it.
- Budget is keyed on **RAM**, not the full snapshot, so it's correct when the full snapshot (e.g. 132 GB) exceeds RAM but the *swept prefix* (66 GB) does not — the case that matters for activations-only profiles.

Eviction is **keep-prefix, not LRU** (documented in code): lens workloads (`run_batch` / `backfill_acts`) sweep the same layer set over N shards — a cyclic access pattern on which LRU is pessimal (Belady) and keep-prefix retains the largest cacheable contiguous prefix.

## Correctness

Pure OS page-cache hint → **activations are bitwise unchanged**, no feature-store regeneration. Caveat (noted in code): accounting is model-based, not a measurement; if the kernel reclaims pages under external pressure the advisor still believes them resident and serves a cold read — perf-only, never wrong activations; the 40% RAM headroom mitigates.

## Tests

- New `TestResidentPageBudget` (default fraction, `FPWAP_PAGE_RESIDENT=0`, `_GB` override, disable-wins precedence) and `TestResidentPageCache` (within-budget suppression, resident revisit counted once, keep-prefix eviction over budget, disabled-budget always evicts).
- Existing advisor / virtual-source tests that assert eager DONTNEED now opt out via `FPWAP_PAGE_RESIDENT=0` — the regime they exercise.
- `204 passed`; mypy strict + ruff clean on `src/fpwap`.

## Verification (not yet run on GPU — handoff recipe)

`/proc/<pid>/io read_bytes` ≈ 0 across shards 2..N; `buff/cache` grows and holds instead of staying flat. CT-side spot check on the 70B truncated self-read read 0 disk bytes/25 s with `buff/cache` 31→90 GB.

## Provenance

First commit is the control-tower agent's throwaway branch (`feat/page-resident-multishard`); second productionizes it (tests, keep-prefix docs, 0.1.3 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)