### PR TITLE
feat: seed a resume under padding="bucketed" (0.1.5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fpwap"
-version = "0.1.4"
+version = "0.1.5"
 description = "Forward Pass Weight Amortization Protocol — invert the inference loop for large transformer models."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -675,11 +675,19 @@ def _stack_seed_residuals(items: list[Any]) -> Tensor:
     return torch.stack([item["residual"] for item in items], dim=0)
 
 
-def _validate_seed_items(items: list[Any], seq_len: int, hidden: int) -> None:
+def _validate_seed_items(
+    items: list[Any], seq_len: int, hidden: int, *, bucketed: bool
+) -> None:
     """A resume seeds the residual buffer instead of embedding; every item must
-    carry a full-sequence `residual` `[seq_len, hidden]` (the input to block
-    `start_layer`). A partial-position residual is not resumable — block
-    `start_layer` attends over the whole prefix."""
+    carry a full-sequence ``residual`` ``[real_len, hidden]`` (the input to block
+    ``start_layer``). A partial-position residual is not resumable — block
+    ``start_layer`` attends over the whole prefix.
+
+    Under ``padding="fixed"`` every item is the same length, so the seed must be
+    exactly ``[seq_len, hidden]``. Under ``padding="bucketed"`` items vary in
+    length, so each seed must match that item's own real length (its
+    ``attention_mask`` sum) — segment building pads it up to the bucket
+    alongside ``input_ids``."""
     for i, item in enumerate(items):
         res = item.get("residual")
         if res is None:
@@ -687,10 +695,20 @@ def _validate_seed_items(items: list[Any], seq_len: int, hidden: int) -> None:
                 "start_layer > 0 seeds the residual buffer, so every dataset item "
                 f"needs a 'residual' tensor; item {i} has none"
             )
-        if res.dim() != 2 or res.shape[0] != seq_len or res.shape[1] != hidden:
+        if bucketed:
+            mask = item.get("attention_mask")
+            if not isinstance(mask, Tensor):
+                raise ValueError(
+                    "padding='bucketed' resume needs an attention_mask on every "
+                    f"item to size its seed residual; item {i} has none"
+                )
+            expected_len = int(mask.sum().item())
+        else:
+            expected_len = seq_len
+        if res.dim() != 2 or res.shape[0] != expected_len or res.shape[1] != hidden:
             raise ValueError(
                 f"seed residual for item {i} must have shape "
-                f"(seq_len={seq_len}, hidden={hidden}); got {tuple(res.shape)}"
+                f"(real_len={expected_len}, hidden={hidden}); got {tuple(res.shape)}"
             )
 
 
@@ -728,9 +746,29 @@ def _detect_left_padding(items: list[Any]) -> bool:
     return True
 
 
+def _trim_residual(t: Tensor, target_len: int, left_padded: bool) -> Tensor:
+    """Pad/trim a seed residual ``[seq, hidden]`` to ``target_len`` on its
+    sequence axis (the side matching the item's padding)."""
+    cur = t.shape[0]
+    if cur == target_len:
+        return t
+    if cur > target_len:
+        return t[-target_len:] if left_padded else t[:target_len]
+    pad = torch.zeros(target_len - cur, t.shape[1], dtype=t.dtype, device=t.device)
+    return torch.cat([pad, t], dim=0) if left_padded else torch.cat([t, pad], dim=0)
+
+
 def _trim_to_length(item: dict[str, Any], target_len: int, left_padded: bool) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, val in item.items():
+        if key == "residual" and isinstance(val, Tensor):
+            # The seed residual [real_len, hidden] rides along with input_ids:
+            # pad/trim its sequence axis to the bucket so Pass 0 writes it into
+            # the [n, bseq, hidden] buffer. Pad positions are causally inert and
+            # the in-loop right-pad trim drops them before the forward, so the
+            # seeded forward still runs at the item's real length.
+            result[key] = _trim_residual(val, target_len, left_padded)
+            continue
         if key not in ("input_ids", "attention_mask") or not isinstance(val, Tensor):
             result[key] = val
             continue
@@ -954,13 +992,20 @@ class Sweep:
     already falls out of the callbacks: the loop stops at the deepest layer any
     callback targets and skips the embedding-to-there and the final norm + head.
     ``start_layer`` is the symmetric lower bound — seed the residual buffer with
-    a stored residual (one ``"residual"`` tensor ``[seq_len, hidden]`` per
-    dataset item, the input to block ``start_layer``) and run only blocks
-    ``[start_layer, N)``. With ``start_layer == 0`` (the default) the buffer is
-    seeded by the embedding pass as usual. Re-running a sub-range of blocks over
-    a bit-identical seed reproduces the cold pass bitwise, so a resume is exact,
-    not approximate — the seed's dtype is the only thing that can perturb it, and
-    that is the caller's to guarantee. Seed mode requires ``padding="fixed"``.
+    a stored residual (one ``"residual"`` tensor per dataset item, the input to
+    block ``start_layer``) and run only blocks ``[start_layer, N)``. With
+    ``start_layer == 0`` (the default) the buffer is seeded by the embedding
+    pass as usual. Re-running a sub-range of blocks over a bit-identical seed
+    reproduces the cold pass bitwise, so a resume is exact, not approximate —
+    the seed's dtype is the only thing that can perturb it, and that is the
+    caller's to guarantee.
+
+    Seed mode works under ``padding="fixed"`` (every item the same length, seed
+    ``[seq_len, hidden]``) and ``padding="bucketed"`` (items of differing
+    length, each seed ``[real_len, hidden]`` matching its ``attention_mask``):
+    bucketed batches units that share a ``start_layer`` into one resume sweep,
+    and the in-loop right-pad trim runs each unit at its real length, so the
+    batched resume matches a solo per-unit resume bitwise.
     """
 
     def __init__(
@@ -1314,13 +1359,20 @@ class Sweep:
         hidden = int(hidden_attr)
         seeding = self.start_layer > 0
         if seeding:
-            if self.padding != "fixed":
+            if self.padding not in ("fixed", "bucketed"):
                 raise NotImplementedError(
-                    "start_layer > 0 (resume from residual) requires padding='fixed'. "
-                    "A resume runs a single start_layer per sweep; batch units that "
-                    "share a seed depth and pad them to a common seq_len."
+                    "start_layer > 0 (resume from residual) supports padding "
+                    f"'fixed' and 'bucketed', not {self.padding!r}."
                 )
-            _validate_seed_items(items, self.seq_len, hidden)
+            # A resume runs a single start_layer per sweep. Under 'fixed' every
+            # item is the same length; under 'bucketed' items of differing
+            # length each carry a real-length seed, and the in-loop right-pad
+            # trim runs each microbatch (size 1) at its real length — so a
+            # batched resume reproduces a solo per-unit resume bitwise, exactly
+            # as cold bucketed reproduces cold fixed.
+            _validate_seed_items(
+                items, self.seq_len, hidden, bucketed=self.padding == "bucketed"
+            )
         pl.resolve_dataset_s = (time.perf_counter_ns() - t0) / 1e9
 
         _emit_progress("preloop_ensure_embedding", -1, 0, 0)

--- a/tests/integration/test_resume_from_residual.py
+++ b/tests/integration/test_resume_from_residual.py
@@ -314,3 +314,188 @@ def test_seed_requires_residual(snapshot: Path) -> None:
     )
     with pytest.raises(ValueError, match="residual"):
         sweep.run()
+
+
+# --- Batched resume: a variable-length batch under padding="bucketed" runs
+#     each unit at its own real length and reproduces the per-unit solo resume
+#     bitwise. This is the lens keyframe-cache batching path: units sharing a
+#     start_layer ride one sweep instead of one sweep each. Needs a wider
+#     position table than the 7-token base snapshot so buckets can differ.
+
+BUCKET_NPOS = 64
+BUCKET_LENGTHS = [40, 12, 9, 33]  # → buckets {40 (capped), 16, 16, 40}: two segments
+
+
+def _write_bucket_snapshot(snapshot_dir: Path) -> None:
+    from transformers import GPT2Config, GPT2LMHeadModel
+
+    config = GPT2Config(
+        vocab_size=VOCAB,
+        n_positions=BUCKET_NPOS,
+        n_embd=HIDDEN,
+        n_layer=N_LAYERS,
+        n_head=N_HEAD,
+    )
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    config.save_pretrained(snapshot_dir)
+
+    torch.manual_seed(SEED + 7)
+    src = GPT2LMHeadModel(config)
+    src.eval()
+    state_dict = {
+        k: v.contiguous() for k, v in src.state_dict().items() if k != "lm_head.weight"
+    }
+    save_file(state_dict, snapshot_dir / "model.safetensors")
+    (snapshot_dir / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"total_size": 0},
+                "weight_map": {k: "model.safetensors" for k in state_dict},
+            }
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def bucket_snapshot(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    d = tmp_path_factory.mktemp("tiny_gpt2_bucket") / "snapshot"
+    _write_bucket_snapshot(d)
+    return d
+
+
+def _solo_cold(
+    snapshot_dir: Path,
+    ids: torch.Tensor,
+    *,
+    compute_dtype: torch.dtype,
+    store_dtype: torch.dtype,
+) -> dict[int, torch.Tensor]:
+    """One unit's cold fixed sweep at its own length — the keyframe-cache 'miss'
+    a batched resume must reproduce, and the source of its seed residual."""
+    from fpwap import Sweep
+    from fpwap.callbacks.common import RawActivations
+
+    sweep = Sweep(
+        model=str(snapshot_dir),
+        dataset=[{"input_ids": ids}],
+        seq_len=int(ids.shape[-1]),
+        callbacks=[
+            RawActivations(
+                layers="all",
+                hook="residual_post",
+                last_token_only=False,
+                out_dtype=store_dtype,
+            )
+        ],
+        transport_dtype=compute_dtype,
+        execution_device="cpu",
+        microbatch_size=1,
+        progress=False,
+    )
+    result = sweep.run()
+    return {
+        layer: result.activations(layer=layer, hook="residual_post")[0]
+        for layer in range(N_LAYERS)
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("compute_dtype,store_dtype", MATCHED_DTYPES)
+@pytest.mark.parametrize("start_layer", [1, 2, 3])
+def test_bucketed_resume_matches_solo(
+    bucket_snapshot: Path,
+    start_layer: int,
+    compute_dtype: torch.dtype,
+    store_dtype: torch.dtype,
+) -> None:
+    """A single bucketed resume sweep over a variable-length batch reproduces
+    each unit's solo per-unit resume bitwise. Units of differing length share
+    one ``start_layer``; the in-loop right-pad trim (microbatch 1) runs each at
+    its real length, so batching is free of numerical cost — the property that
+    lets the keyframe cache batch same-start_layer units without breaking the
+    hit==miss bit-exactness guarantee."""
+    torch.manual_seed(SEED + 8)
+    ids = [torch.randint(0, VOCAB, (1, length)) for length in BUCKET_LENGTHS]
+
+    solo = [
+        _solo_cold(bucket_snapshot, x, compute_dtype=compute_dtype, store_dtype=store_dtype)
+        for x in ids
+    ]
+    # The input to block start_layer is residual_post of block start_layer - 1,
+    # at each unit's own real length.
+    seeds = [s[start_layer - 1] for s in solo]
+
+    max_len = max(BUCKET_LENGTHS)
+    dataset = []
+    for x, seed, length in zip(ids, seeds, BUCKET_LENGTHS, strict=True):
+        padded = torch.zeros(1, max_len, dtype=torch.long)
+        padded[0, :length] = x[0]
+        mask = torch.zeros(1, max_len, dtype=torch.long)
+        mask[0, :length] = 1
+        dataset.append({"input_ids": padded, "attention_mask": mask, "residual": seed})
+
+    from fpwap import Sweep
+    from fpwap.callbacks.common import RawActivations
+
+    sweep = Sweep(
+        model=str(bucket_snapshot),
+        dataset=dataset,
+        seq_len=max_len,
+        padding="bucketed",
+        callbacks=[
+            RawActivations(
+                layers=list(range(start_layer, N_LAYERS)),
+                hook="residual_post",
+                last_token_only=False,
+                out_dtype=store_dtype,
+            )
+        ],
+        transport_dtype=compute_dtype,
+        execution_device="cpu",
+        microbatch_size=1,
+        start_layer=start_layer,
+        progress=False,
+    )
+    result = sweep.run()
+
+    for i, length in enumerate(BUCKET_LENGTHS):
+        for layer in range(start_layer, N_LAYERS):
+            got = result.activations(layer=layer, hook="residual_post")[i, :length]
+            exp = solo[i][layer]
+            max_abs = (got.float() - exp.float()).abs().max().item()
+            assert torch.equal(got, exp), (
+                f"bucketed resume from {start_layer}: unit {i} (len {length}) "
+                f"layer {layer} diverged from solo (max_abs={max_abs})"
+            )
+
+
+@pytest.mark.integration
+def test_bucketed_resume_validates_seed_length(bucket_snapshot: Path) -> None:
+    """A bucketed seed must match its item's real length (mask sum), not the
+    padded width — a mis-sized seed is a loud error, never a silent mis-seed."""
+    from fpwap import Sweep
+    from fpwap.callbacks.common import RawActivations
+
+    torch.manual_seed(SEED + 9)
+    length, max_len = 12, 16
+    padded = torch.zeros(1, max_len, dtype=torch.long)
+    padded[0, :length] = torch.randint(0, VOCAB, (length,))
+    mask = torch.zeros(1, max_len, dtype=torch.long)
+    mask[0, :length] = 1
+    # Seed sized to the padded width (16) instead of the real length (12).
+    bad_seed = torch.zeros(max_len, HIDDEN)
+
+    sweep = Sweep(
+        model=str(bucket_snapshot),
+        dataset=[{"input_ids": padded, "attention_mask": mask, "residual": bad_seed}],
+        seq_len=max_len,
+        padding="bucketed",
+        callbacks=[RawActivations(layers=[3], hook="residual_post")],
+        transport_dtype=torch.float32,
+        execution_device="cpu",
+        microbatch_size=1,
+        start_layer=2,
+        progress=False,
+    )
+    with pytest.raises(ValueError, match="real_len"):
+        sweep.run()

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "fpwap"
-version = "0.1.3"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary

Lets a **resume** (`start_layer > 0`) run under `padding="bucketed"`, so units of differing length that share a `start_layer` ride **one** resume sweep instead of one sweep each. This is the engine half of the lens keyframe-cache batching path (same-`start_layer` resume batching).

Previously seeding required `padding="fixed"` (uniform length), so a batch of varying-length units could not amortize weight streaming across a resume.

## Why it stays bitwise

The bit-exactness guarantee — *a cache hit returns identical bits to a cold miss* — is preserved by the **same** machinery that already makes a *cold* bucketed read reproduce a cold fixed read bitwise: the 0.1.1 in-loop right-pad trim (`engine.py` forward loop). With `microbatch_size=1`, every unit's forward is trimmed to its **own real length**, so a batched resume reproduces a solo per-unit resume bitwise.

Padding a unit up to a common bucket and running the forward at the bucket length would instead perturb bf16 via shape-dependent kernel selection (which MoE routing amplifies into macroscopic per-token divergence — the original 0.1.0 bucketed divergence). The per-microbatch trim is exactly what avoids that, and the seed rides along through it.

## Changes

- Lift the `padding != "fixed"` rejection in the seeding gate to allow `"bucketed"`.
- `_validate_seed_items`: under bucketed, each seed must match its item's **real length** (`attention_mask` sum), not the global `seq_len`; segment building pads it up to the bucket alongside `input_ids`.
- `_trim_to_length`: carry the `"residual"` field, padding/trimming its sequence axis on the item's padding side (new `_trim_residual` helper).
- `Sweep` docstring: document bucketed seed mode.
- Version bump `0.1.4 → 0.1.5` (+ `uv.lock`, which was stale at 0.1.3 on main).

## Tests

`tests/integration/test_resume_from_residual.py` (tiny GPT2, CPU):

- **`test_bucketed_resume_matches_solo`** — a variable-length batch `[40, 12, 9, 33]` spanning two buckets reproduces each unit's solo per-unit resume **bitwise**, for fp32 and bf16, at `start_layer` 1/2/3. (The GPT2 learned-position warning fires but the assertion passes bitwise — confirming the warning is conservative: `mb=1` trims each unit to exact real length, so positions match a solo run.)
- **`test_bucketed_resume_validates_seed_length`** — a seed sized to the padded width instead of the real length is a loud error, never a silent mis-seed.

Full suite: 212 unit + 106 integration pass; mypy + ruff clean. No regression to cold bucketed.

## Follow-up (lens, blocked on the 0.1.5 release)

lens will wire same-`start_layer` resume batching into `run_batch`/`read_units_cached` on top of this, plus the `K==N` exact-hit short-circuit and on-by-default cache wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)