### PR TITLE
Disable worker weight prefetch by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ affects downstream compute), all four reference callbacks shipped
 `result.activations(...)`, tqdm progress plus callable `progress=reporter`
 emitting `ProgressEvent`s for wandb/rich sinks, pinned-CPU
 `buffer_device="cpu"` with async D2H copy (so oversized residual buffers
-don't block compute), worker-thread **concurrent weight prefetch** on the
-streaming path (layer L+1's safetensors read + H2D overlap with layer L's
-compute), `MemmapBackend` for disk-backed emits,
+don't block compute), opt-in worker-thread **concurrent weight prefetch** on
+the streaming path (`FPWAP_PREFETCH_LOAD=1`, layer L+1's safetensors read +
+H2D overlap with layer L's compute), `MemmapBackend` for disk-backed emits,
 `ProfileReport.throughput_tok_per_s()` / `weight_bandwidth_gb_per_s()`,
 `verify=True` fail-fast against a naive-forward baseline (pre-loaded
 models), per-layer `on_layer_end` artifacts collected into

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fpwap"
-version = "0.1.5"
+version = "0.1.6"
 description = "Forward Pass Weight Amortization Protocol — invert the inference loop for large transformer models."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/fpwap/engine.py
+++ b/src/fpwap/engine.py
@@ -39,6 +39,17 @@ from fpwap.types import (
 ProgressReporter = Callable[["ProgressEvent"], None]
 
 
+def _weight_prefetch_enabled() -> bool:
+    """Whether to overlap next-layer weight loads with current-layer compute.
+
+    Disabled by default for correctness. On large MoE fp8 sweeps, concurrent
+    worker-thread module mutation plus staged CUDA copies can corrupt activations
+    or trip device-side index asserts. Keep the fast path opt-in until it has a
+    stronger synchronization contract.
+    """
+    return os.environ.get("FPWAP_PREFETCH_LOAD", "0") not in ("0", "false", "False")
+
+
 @dataclass(frozen=True)
 class ProgressEvent:
     """Emitted by the engine at layer and batch boundaries.
@@ -535,20 +546,24 @@ class _OffloadStreamer(_LayerStreamer):
             for target, plan in plans.items()
         }
         self._advisor = ShardPageAdvisor(accel_index, virtual_sources=virtual_sources)
-        # Single-worker pool: next layer's load runs on a worker thread so
-        # safetensors read + H2D overlap with the main thread's compute on
-        # the current layer. Modern GPUs have a separate copy engine, so
-        # worker-stream H2D and main-stream compute progress concurrently.
+        # Optional single-worker pool: next layer's load runs on a worker
+        # thread so safetensors read + H2D overlap with the main thread's
+        # compute on the current layer. This is an explicit opt-in because
+        # staged worker-thread prefetch has triggered activation corruption on
+        # long Qwen3-MoE fp8 sweeps.
         import concurrent.futures as _cf
         import weakref
 
-        self._prefetch_pool: _cf.ThreadPoolExecutor | None = _cf.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="fpwap-prefetch"
-        )
+        self._prefetch_pool: _cf.ThreadPoolExecutor | None = None
+        if _weight_prefetch_enabled():
+            self._prefetch_pool = _cf.ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="fpwap-prefetch"
+            )
         # Safety net: if Sweep.run() raises before reaching the explicit
         # close() at the end, the finalizer shuts the pool down on GC so a
         # caller looping Sweep constructions doesn't leak worker threads.
-        weakref.finalize(self, _cf.ThreadPoolExecutor.shutdown, self._prefetch_pool, True)
+        if self._prefetch_pool is not None:
+            weakref.finalize(self, _cf.ThreadPoolExecutor.shutdown, self._prefetch_pool, True)
 
     def ensure_embedding_loaded(self, model: nn.Module, plumbing: ModelPlumbing) -> None:
         device = self.execution_device

--- a/tests/unit/test_weight_prefetch_gate.py
+++ b/tests/unit/test_weight_prefetch_gate.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from fpwap.engine import _weight_prefetch_enabled
+
+
+def test_weight_prefetch_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FPWAP_PREFETCH_LOAD", raising=False)
+
+    assert _weight_prefetch_enabled() is False
+
+
+def test_weight_prefetch_can_be_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FPWAP_PREFETCH_LOAD", "1")
+
+    assert _weight_prefetch_enabled() is True
+
+
+def test_weight_prefetch_false_spellings(monkeypatch: pytest.MonkeyPatch) -> None:
+    for value in ("0", "false", "False"):
+        monkeypatch.setenv("FPWAP_PREFETCH_LOAD", value)
+
+        assert _weight_prefetch_enabled() is False

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "fpwap"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary
- disable worker-thread weight prefetch by default behind `FPWAP_PREFETCH_LOAD=1`
- keep staged layer loading enabled; only the next-layer prefetch overlap is gated
- document the opt-in flag and add unit coverage for the gate
- bump package version to `0.1.6` so the release workflow publishes this fix to PyPI on merge

## Why
Lens fp8 Qwen3-MoE batched reads exposed activation corruption and CUDA index asserts when staged layer loads overlapped with current-layer compute via the worker prefetch thread. Disabling only `_OffloadStreamer.prefetch_load` kept the known poisoned shards finite while leaving `FPWAP_STAGED_LOAD=1` active.

## Validation
- `uv run pytest tests/unit/test_weight_prefetch_gate.py tests/unit/test_cost_model.py tests/unit/test_preflight_report.py`
- `uv run pytest tests/unit`
- `uv run ruff check src tests/unit/test_weight_prefetch_gate.py`
- `uv run mypy src/fpwap tests/unit/test_weight_prefetch_gate.py`
- `uv run pytest tests/gpu/test_staged_layer_load.py -m gpu` -> 5 passed
- `uv build` -> built `dist/fpwap-0.1.6.tar.gz` and `dist/fpwap-0.1.6-py3-none-any.whl`
- lens monkeypatch full-corpus validation with staged load on and prefetch disabled: `420/420` stored, activation scan `420 files / 0 bad`, surprise nonfinite scan `420 files / 0 bad`, `VERDICT PASS`
- lens promotion check on the clean store: `420` records, `420` unique keys, single expected profile/revision/eval SHA, complete feature-file set for every unit
- lens patched-source validation without monkeypatch: imported fpwap from this branch, `FPWAP_PREFETCH_LOAD` unset, `_weight_prefetch_enabled() == False`; known previously poisoned 3-unit shard returned finite activations (`absmax` 7.78125, 9.0625, 8.3125; nonfinite 0)